### PR TITLE
Add pagination support for announcements and bulletin counter fetching

### DIFF
--- a/src/api/messageProtocol/mock.ts
+++ b/src/api/messageProtocol/mock.ts
@@ -11,6 +11,7 @@ import {
   IMessageProtocol,
   EncryptedMessage,
   MessageProtocolResponse,
+  PaginatedAnnouncementsResponse,
 } from './types';
 
 export class MockMessageProtocol implements IMessageProtocol {
@@ -75,6 +76,56 @@ export class MockMessageProtocol implements IMessageProtocol {
     // Return empty array for now - in a real implementation, this would
     // simulate fetching from a global announcement channel
     return this.mockAnnouncements;
+  }
+
+  async fetchAnnouncementsFromCursor(
+    cursor?: string,
+    limit: number = 100
+  ): Promise<PaginatedAnnouncementsResponse> {
+    console.log(
+      'Mock: Fetching announcements from cursor:',
+      cursor,
+      'limit:',
+      limit
+    );
+
+    // Simulate network delay
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    // Parse cursor as starting index (1-based counter)
+    // Using BigInt for proper U256 support, but for mock we keep it simple with numbers
+    const startIndex = cursor ? parseInt(cursor, 10) - 1 : 0;
+    const endIndex = Math.min(
+      startIndex + limit,
+      this.mockAnnouncements.length
+    );
+    const slicedAnnouncements = this.mockAnnouncements.slice(
+      startIndex,
+      endIndex
+    );
+    const hasMore = endIndex < this.mockAnnouncements.length;
+    const nextCursor = hasMore ? String(endIndex + 1) : null;
+
+    // Create items with counter values
+    const items = slicedAnnouncements.map((data, index) => ({
+      counter: String(startIndex + index + 1), // 1-based counter
+      data,
+    }));
+
+    return {
+      items,
+      nextCursor,
+      hasMore,
+    };
+  }
+
+  async fetchBulletinCounter(): Promise<string> {
+    console.log('Mock: Fetching bulletin counter');
+
+    // Simulate network delay
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    return String(this.bulletinCounter);
   }
 
   async fetchPublicKeyByUserId(userId: Uint8Array): Promise<string> {

--- a/src/api/messageProtocol/types.ts
+++ b/src/api/messageProtocol/types.ts
@@ -14,6 +14,23 @@ export interface MessageProtocolResponse<T = unknown> {
 }
 
 /**
+ * A bulletin item with its counter value
+ */
+export interface BulletinItem {
+  counter: string; // String to support U256 bigint values
+  data: Uint8Array;
+}
+
+/**
+ * Response for paginated bulletin fetching
+ */
+export interface PaginatedAnnouncementsResponse {
+  items: BulletinItem[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+/**
  * Abstract interface for message protocol operations
  */
 export interface IMessageProtocol {
@@ -36,8 +53,28 @@ export interface IMessageProtocol {
   /**
    * Fetch incoming discussion announcements from the bulletin storage.
    * Returns raw announcement bytes as provided by the API.
+   * @deprecated Use fetchAnnouncementsFromCursor for paginated fetching
    */
   fetchAnnouncements(): Promise<Uint8Array[]>;
+
+  /**
+   * Fetch announcements starting from a specific cursor (counter).
+   * Uses cursor-based pagination for efficient incremental fetching.
+   * @param cursor - The bulletin counter to start fetching from (exclusive). Pass "1" or undefined for first fetch.
+   * @param limit - Maximum number of bulletins to fetch per page (default: 100, max: 1000)
+   * @returns Paginated response with announcements, next cursor, and hasMore flag
+   */
+  fetchAnnouncementsFromCursor(
+    cursor?: string,
+    limit?: number
+  ): Promise<PaginatedAnnouncementsResponse>;
+
+  /**
+   * Fetch the current bulletin counter from the API.
+   * Useful to check if there are new bulletins without fetching them all.
+   * @returns The current bulletin counter as a string
+   */
+  fetchBulletinCounter(): Promise<string>;
 
   /**
    * Fetch public key by userId hash (base64 string)

--- a/src/db.ts
+++ b/src/db.ts
@@ -67,6 +67,7 @@ export interface UserProfile {
   createdAt: Date;
   updatedAt: Date;
   lastPublicKeyPush?: Date;
+  lastBulletinCounter?: string; // Last processed bulletin counter for incremental fetching
 }
 
 // Unified discussion interface combining protocol state and UI metadata


### PR DESCRIPTION
- Introduced cursor-based pagination for fetching announcements in both mock and REST message protocols.
- Updated the `IMessageProtocol` interface to include `fetchAnnouncementsFromCursor` and `fetchBulletinCounter` methods.
- Enhanced the `AnnouncementService` to incrementally fetch announcements based on the last processed bulletin counter, improving efficiency and user experience.
- Added a new `PaginatedAnnouncementsResponse` type for structured response handling.