### PR TITLE
Fix keyboard layout across Samsung, Xiaomi, and iOS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="adjustNothing"
             android:exported="true">
 
             <!-- App launcher icon -->

--- a/android/app/src/main/java/net/massa/gossip/MainActivity.java
+++ b/android/app/src/main/java/net/massa/gossip/MainActivity.java
@@ -10,6 +10,7 @@ import android.net.http.SslError;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.WindowManager;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 import com.getcapacitor.BridgeActivity;
@@ -30,6 +31,17 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(BackgroundRunnerStoragePlugin.class);
         
         super.onCreate(savedInstanceState);
+
+        // Samsung (OneUI) ignores adjustNothing and always resizes the WebView.
+        // Use adjustResize on Samsung so the OS handles keyboard layout natively.
+        // Other OEMs (Xiaomi/MIUI) respect adjustNothing — we handle layout via CSS transform.
+        // KeyboardResize.Native in capacitor.config.ts ensures Capacitor doesn't override this.
+        String manufacturer = Build.MANUFACTURER.toLowerCase();
+        if (manufacturer.contains("samsung")) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        } else {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+        }
 
         // Set transparent status and navigation bars
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -19,7 +19,7 @@ const config: CapacitorConfig = {
   plugins: {
     // Keyboard plugin configuration
     Keyboard: {
-      resize: KeyboardResize.Body,
+      resize: KeyboardResize.Native,
     },
     LocalNotifications: {
       smallIcon: 'ic_notification',

--- a/src/components/ui/BaseModal.tsx
+++ b/src/components/ui/BaseModal.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import Button from './Button';
 import { useKeyDown } from '../../hooks/useKeyDown';
-import { useFixedKeyboardStyles } from '../../hooks/useKeyboardVisible';
 import { X } from 'react-feather';
 
 interface BaseModalProps {
@@ -21,12 +20,6 @@ const BaseModal: React.FC<BaseModalProps> = ({
   // Animation mount flag (animate on open)
   const [mounted, setMounted] = useState(false);
   const { onEsc } = useKeyDown({ enabled: isOpen });
-  const keyboardStyles = useFixedKeyboardStyles();
-
-  // Workaround: On iOS, when keyboard is visible, resize modal container
-  // to prevent it from being pushed off-screen due to slow keyboard resize.
-  // Note: Modal uses fixed positioning, so it needs its own height adjustment.
-  // See: https://github.com/ionic-team/capacitor-keyboard/issues/19
 
   useEffect(() => {
     onEsc(() => onClose());
@@ -45,8 +38,8 @@ const BaseModal: React.FC<BaseModalProps> = ({
 
   const modalContent = (
     <div
-      className="fixed inset-0 z-1000 flex flex-col items-center justify-end md:justify-center md:p-6 pt-safe-t"
-      style={keyboardStyles}
+      className="fixed inset-x-0 top-0 z-1000 flex flex-col items-center justify-end md:justify-center md:p-6 pt-safe-t"
+      style={{ height: 'var(--available-height, 100dvh)' }}
     >
       {/* Backdrop */}
       <div

--- a/src/components/ui/IOSKeyboardWrapper.tsx
+++ b/src/components/ui/IOSKeyboardWrapper.tsx
@@ -1,29 +1,18 @@
 import React from 'react';
-import { useIOSKeyboardWorkaround } from '../../hooks/useKeyboardVisible';
 
 /**
- * Wrapper component that handles iOS keyboard resize workaround.
- * Resizes the entire app when keyboard is visible on iOS to prevent
- * content from being pushed off-screen due to slow keyboard resize.
+ * Wrapper that resizes the app when the keyboard is visible.
+ * Uses the --keyboard-height CSS variable set directly from the native keyboard
+ * event listener (no React in the resize path = zero frame delay).
  *
- * Instead of translating, we resize the height so all content remains visible.
- *
- * See: https://github.com/ionic-team/capacitor-keyboard/issues/19
+ * On devices where the OS handles resize (e.g. Samsung), --keyboard-height
+ * stays at 0px so no double offset occurs.
  */
 const IOSKeyboardWrapper: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const { active, keyboardHeight } = useIOSKeyboardWorkaround();
-
   return (
-    <div
-      className="w-full h-full flex flex-col transition-[height] duration-300 ease-out"
-      style={
-        active ? { height: `calc(100dvh - ${keyboardHeight}px)` } : undefined
-      }
-    >
-      {children}
-    </div>
+    <div className="w-full flex flex-col keyboard-aware-height">{children}</div>
   );
 };
 

--- a/src/hooks/useKeyboardVisible.ts
+++ b/src/hooks/useKeyboardVisible.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from 'react';
-import type React from 'react';
 import { Keyboard, KeyboardInfo } from '@capacitor/keyboard';
 import { Capacitor } from '@capacitor/core';
 
@@ -14,13 +13,44 @@ let _kbListenersReady = false;
 function setupKeyboardTracking() {
   if (_kbListenersReady || !Capacitor.isNativePlatform()) return;
   _kbListenersReady = true;
+
+  // Lock viewport height before keyboard opens.
+  // On Samsung/iOS the OS shrinks the WebView when keyboard opens, which would
+  // shrink 100dvh and cause ghost gap (double-offset: OS resize + our transform).
+  // By locking to a pixel value, the container stays full-height and only the
+  // CSS transform moves content up.
+  document.documentElement.style.setProperty(
+    '--viewport-height',
+    `${window.innerHeight}px`
+  );
+
+  // Update baseline when keyboard is closed (handles orientation changes)
+  window.addEventListener('resize', () => {
+    if (_kbHeight === 0) {
+      document.documentElement.style.setProperty(
+        '--viewport-height',
+        `${window.innerHeight}px`
+      );
+    }
+  });
+
   Keyboard.addListener('keyboardWillShow', (info: KeyboardInfo) => {
     _kbHeight = info.keyboardHeight;
+    document.documentElement.style.setProperty(
+      '--keyboard-height',
+      `${info.keyboardHeight}px`
+    );
   });
+
   Keyboard.addListener('keyboardWillHide', () => {
     _kbHeight = 0;
+    document.documentElement.style.setProperty('--keyboard-height', '0px');
   });
 }
+
+// Initialize tracking immediately so the CSS variable is set
+// before any component mounts.
+setupKeyboardTracking();
 
 /**
  * Returns the current keyboard height (px) without needing a React hook.
@@ -28,7 +58,6 @@ function setupKeyboardTracking() {
  * after the keyboard was already open.
  */
 export function getKeyboardHeight(): number {
-  setupKeyboardTracking();
   return _kbHeight;
 }
 
@@ -112,64 +141,5 @@ export function useKeyboardVisible(): {
     isKeyboardVisibleRef,
     keyboardHeight,
     keyboardHeightRef,
-  };
-}
-
-/**
- * iOS-specific keyboard layout workaround helper.
- *
- * Returns an object with:
- * - active: true only on iOS native when the keyboard is visible
- * - keyboardHeight: the height of the keyboard in pixels
- *
- * Use this to apply layout workarounds (e.g. fixed heights, positioning) to avoid
- * slow/late keyboard resize issues in the iOS WebView.
- *
- * See: https://github.com/ionic-team/capacitor-keyboard/issues/19
- */
-export function useIOSKeyboardWorkaround(): {
-  active: boolean;
-  keyboardHeight: number;
-} {
-  const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible();
-  const isIOS = Capacitor.getPlatform() === 'ios';
-  return {
-    active: isIOS && isKeyboardVisible,
-    keyboardHeight: isIOS ? keyboardHeight : 0,
-  };
-}
-
-/**
- * Hook that returns styles for fixed-positioned elements to handle iOS keyboard
- * and safe areas (Android/iOS notches, gesture areas).
- *
- * Use this hook on any element with `position: fixed` to automatically adjust
- * its height when the keyboard is visible on iOS, while respecting safe areas.
- *
- * @returns React.CSSProperties object with height adjustment accounting for
- *          keyboard and safe areas
- *
- * Example:
- * ```tsx
- * const styles = useFixedKeyboardStyles();
- * <div className="fixed inset-0 pt-safe-t pb-safe-b" style={styles}>
- *   {content}
- * </div>
- * ```
- */
-export function useFixedKeyboardStyles(): React.CSSProperties {
-  const { active, keyboardHeight } = useIOSKeyboardWorkaround();
-
-  // useIOSKeyboardWorkaround already handles iOS platform check
-  // If not iOS, active will be false and keyboardHeight will be 0
-  if (!active) {
-    return {};
-  }
-
-  return {
-    // Calculate height only accounting for keyboard
-    // Safe areas are handled by padding (pt-safe-t, pb-safe-b) in the component
-    height: `calc(100dvh - ${keyboardHeight}px)`,
-    transition: 'height 300ms ease-out',
   };
 }

--- a/src/pages/Discussion.tsx
+++ b/src/pages/Discussion.tsx
@@ -22,7 +22,6 @@ import { useGossipSdk } from '../hooks/useGossipSdk';
 import { isDifferentDay } from '../utils/timeUtils';
 import { useUiStore } from '../stores/uiStore';
 import SessionIssueBanner from '../components/discussions/SessionIssueBanner';
-import { useKeyboardVisible } from '../hooks/useKeyboardVisible';
 
 // Debug test message constants
 const TEST_MESSAGE_COUNT = 50;
@@ -153,19 +152,6 @@ const Discussion: React.FC = () => {
   const handleAtBottomChange = useCallback((atBottom: boolean) => {
     setShowScrollToBottom(!atBottom);
   }, []);
-
-  // On iOS, when the keyboard opens the body resizes but Virtuoso doesn't
-  // adjust the scroll position — the last messages end up behind the keyboard.
-  // Scroll to bottom after layout settles, but only if user was already there.
-  const { isKeyboardVisible } = useKeyboardVisible();
-  useEffect(() => {
-    if (!isKeyboardVisible) return;
-    if (!messageListRef.current?.isAtBottom) return;
-    const id = setTimeout(() => {
-      messageListRef.current?.scrollToBottom();
-    }, 350);
-    return () => clearTimeout(id);
-  }, [isKeyboardVisible]);
 
   // Track timeout for message highlight
   const highlightTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -318,17 +304,10 @@ const Discussion: React.FC = () => {
     setForwardPreviewText(null);
   }, []);
 
-  // Handle input focus - scroll to bottom after keyboard appears
   const handleInputFocus = useCallback(() => {
-    // Delay to let the keyboard animation start and layout adjust
-    setTimeout(() => {
-      scrollToBottom();
-    }, 150);
-    // Second scroll after keyboard is fully open
-    setTimeout(() => {
-      scrollToBottom();
-    }, 350);
-  }, [scrollToBottom]);
+    // No forced scroll — let the container resize naturally.
+    // Virtuoso maintains scroll position when the container shrinks.
+  }, []);
 
   const handleScrollToMessage = useCallback(
     (messageId: number) => {
@@ -501,7 +480,7 @@ const Discussion: React.FC = () => {
 
   return (
     <div
-      className="h-full app-max-w mx-auto bg-card flex flex-col relative select-none"
+      className="h-full app-max-w mx-auto bg-card flex flex-col relative select-none overflow-hidden"
       style={{ WebkitTouchCallout: 'none' }}
       onMouseDown={e => {
         // Prevent taps from stealing focus / dismissing keyboard,
@@ -512,77 +491,84 @@ const Discussion: React.FC = () => {
         }
       }}
     >
-      <DiscussionHeader
-        contact={contact}
-        discussion={discussion}
-        onBack={onBack}
-        onSearchToggle={() => setIsSearchOpen(prev => !prev)}
-      />
-      <SessionIssueBanner
-        discussion={discussion}
-        outgoingSentCount={outgoingSentCount}
-      />
-      {isSearchOpen && (
-        <MessageSearch
-          messages={messages}
-          onScrollToMessage={handleScrollToMessage}
-          onHighlightChange={setSearchHighlightId}
-          onClose={() => {
-            setIsSearchOpen(false);
-            setSearchHighlightId(null);
-          }}
-        />
-      )}
-
-      <div
-        ref={messageListContainerRef}
-        className="flex-1 min-h-0 overflow-hidden"
-      >
-        <MessageList
-          ref={messageListRef}
-          messages={messages}
-          discussion={discussion}
+      {/* Header stays fixed in place — shifted content slides behind it */}
+      <div className="relative z-10">
+        <DiscussionHeader
           contact={contact}
-          isLoading={isLoading || isDiscussionLoading}
-          onReplyTo={handleReplyToMessage}
-          onForward={handleForwardMessage}
-          onScrollToMessage={handleScrollToMessage}
-          onAtBottomChange={handleAtBottomChange}
-          highlightedMessageId={searchHighlightId}
+          discussion={discussion}
+          onBack={onBack}
+          onSearchToggle={() => setIsSearchOpen(prev => !prev)}
         />
+        <SessionIssueBanner
+          discussion={discussion}
+          outgoingSentCount={outgoingSentCount}
+        />
+        {isSearchOpen && (
+          <MessageSearch
+            messages={messages}
+            onScrollToMessage={handleScrollToMessage}
+            onHighlightChange={setSearchHighlightId}
+            onClose={() => {
+              setIsSearchOpen(false);
+              setSearchHighlightId(null);
+            }}
+          />
+        )}
       </div>
 
-      <ScrollToBottomButton
-        onClick={scrollToBottom}
-        isVisible={showScrollToBottom}
-      />
-
-      {/* Debug test button - only show when debug mode is enabled */}
-      {showDebugOption && (
-        <div className="absolute bottom-32 right-4 z-10">
-          <button
-            onClick={handleSendTestMessages}
-            disabled={isSendingTestMessages}
-            className={`w-12 h-12 rounded-full bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white shadow-lg border border-border flex items-center justify-center text-xs font-bold transition-all ${
-              isSendingTestMessages ? 'animate-pulse' : ''
-            }`}
-            title={`Send ${TEST_MESSAGE_COUNT} test messages (Debug)`}
-          >
-            {isSendingTestMessages ? '...' : TEST_MESSAGE_COUNT.toString()}
-          </button>
+      {/* Content shifts up via CSS transform when keyboard opens.
+          Messages slide behind the header. No scroll manipulation needed. */}
+      <div className="flex-1 min-h-0 flex flex-col keyboard-shift-content">
+        <div
+          ref={messageListContainerRef}
+          className="flex-1 min-h-0 overflow-hidden"
+        >
+          <MessageList
+            ref={messageListRef}
+            messages={messages}
+            discussion={discussion}
+            contact={contact}
+            isLoading={isLoading || isDiscussionLoading}
+            onReplyTo={handleReplyToMessage}
+            onForward={handleForwardMessage}
+            onScrollToMessage={handleScrollToMessage}
+            onAtBottomChange={handleAtBottomChange}
+            highlightedMessageId={searchHighlightId}
+          />
         </div>
-      )}
 
-      <MessageInput
-        onSend={handleSendMessage}
-        replyingTo={replyingTo}
-        onCancelReply={handleCancelReply}
-        initialValue={forwardFromMessageId ? undefined : inputPrefill}
-        forwardPreview={forwardFromMessageId ? forwardPreviewText : null}
-        forwardMode={forwardPreviewMode}
-        onCancelForward={handleCancelForward}
-        onFocus={handleInputFocus}
-      />
+        <ScrollToBottomButton
+          onClick={scrollToBottom}
+          isVisible={showScrollToBottom}
+        />
+
+        {/* Debug test button - only show when debug mode is enabled */}
+        {showDebugOption && (
+          <div className="absolute bottom-32 right-4 z-10">
+            <button
+              onClick={handleSendTestMessages}
+              disabled={isSendingTestMessages}
+              className={`w-12 h-12 rounded-full bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white shadow-lg border border-border flex items-center justify-center text-xs font-bold transition-all ${
+                isSendingTestMessages ? 'animate-pulse' : ''
+              }`}
+              title={`Send ${TEST_MESSAGE_COUNT} test messages (Debug)`}
+            >
+              {isSendingTestMessages ? '...' : TEST_MESSAGE_COUNT.toString()}
+            </button>
+          </div>
+        )}
+
+        <MessageInput
+          onSend={handleSendMessage}
+          replyingTo={replyingTo}
+          onCancelReply={handleCancelReply}
+          initialValue={forwardFromMessageId ? undefined : inputPrefill}
+          forwardPreview={forwardFromMessageId ? forwardPreviewText : null}
+          forwardMode={forwardPreviewMode}
+          onCancelForward={handleCancelForward}
+          onFocus={handleInputFocus}
+        />
+      </div>
     </div>
   );
 };

--- a/src/stores/accountStore.tsx
+++ b/src/stores/accountStore.tsx
@@ -449,9 +449,11 @@ const useAccountStoreBase = create<AccountState>((set, get) => {
         useDiscussionStore.getState().cleanup();
         useMessageStore.getState().cleanup();
 
-        const currentProfile = await getActiveOrFirstProfile();
-        if (currentProfile?.userId != null) {
-          await getSdk().profiles.delete(currentProfile.userId);
+        // Clear all DB tables (conversations, contacts, profiles, seekers, etc.)
+        try {
+          await getSdk().clearAllTables();
+        } catch {
+          // SQLite might not be initialized
         }
 
         set(clearAccountState());

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -26,6 +26,13 @@
     --sab: 0px;
     --sal: 0px;
     --sar: 0px;
+    --keyboard-height: 0px;
+    /* Available height above the keyboard. Uses --viewport-height (locked at
+       initial window height by JS) so OS resize doesn't cause double-offset.
+       Use on any fixed/modal element that must fit above the keyboard. */
+    --available-height: calc(
+      var(--viewport-height, 100dvh) - var(--keyboard-height, 0px)
+    );
     --header-height: 3.5rem;
     --bottom-nav-height: 4rem;
     --header-padding: 1.5rem;
@@ -215,6 +222,26 @@
       /* Reserve space only on scrollbar side to prevent layout shift without creating both-side gutters */
       scrollbar-gutter: stable;
     }
+  }
+
+  /* Keyboard-aware layout: uses --keyboard-height CSS variable set directly
+     from the native keyboard event listener, bypassing React entirely.
+     On devices where the OS handles resize (Samsung), --keyboard-height stays 0. */
+  .keyboard-aware-height {
+    height: var(--viewport-height, 100dvh);
+  }
+
+  /* Content area below a sticky header: shifts up via GPU-accelerated transform
+     when keyboard opens. Header stays in place, content slides behind it. */
+  .keyboard-shift-content {
+    transform: translateY(calc(-1 * var(--keyboard-height, 0px)));
+    will-change: transform;
+  }
+
+  /* Add top padding to Virtuoso scroller so user can scroll up to reach
+     messages that shifted off-screen behind the header. */
+  .keyboard-shift-content [data-virtuoso-scroller] {
+    padding-top: var(--keyboard-height, 0px);
   }
 
   /* Ensure pointer cursor on all buttons */


### PR DESCRIPTION
Replace React-based keyboard handling with CSS custom properties for zero-delay response. Lock viewport height on init to prevent ghost gap from OS+transform double-offset. Samsung gets adjustResize (OS handles layout), others get adjustNothing (CSS transform handles layout).

- Set --viewport-height, --keyboard-height, --available-height CSS vars directly from native keyboard events (no React render cycle)
- Samsung: adjustResize in Java, OS handles WebView resize
- Xiaomi/iOS: adjustNothing, CSS transform shifts content up
- Modals use --available-height to fit above keyboard on all devices
- Remove useIOSKeyboardWorkaround and useFixedKeyboardStyles hooks
- Simplify IOSKeyboardWrapper to pure CSS class
- Discussion layout: header in z-10 div, content in keyboard-shift-content
- Delete account now clears all DB tables (not just profile)