### PR TITLE
fix(ui): synchronisation du thème (DOM + persistance)

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,29 +1,24 @@
 import { useCallback } from 'react';
 import { useUiStore } from '../stores/uiStore';
 import { Theme } from '../stores/uiStore';
-import { resolveTheme } from '../utils/themeUtils';
+import {
+  applyResolvedThemeToDocument,
+  resolveTheme,
+} from '../utils/themeUtils';
 import { initStatusBar } from './useCapacitorBarColors';
 
 // Store the media query listener cleanup function
 let mediaQueryListener: ((event: MediaQueryListEvent) => void) | null = null;
 let mediaQuery: MediaQueryList | null = null;
-// Store the theme subscription cleanup function
-let unsubscribeTheme: (() => void) | null = null;
 
 /**
- * Update theme and apply it to the DOM
+ * Sync resolved theme + DOM when preference is "system" (OS theme changes).
+ * User theme changes go through uiStore.setTheme (also updates DOM).
  */
-const updateTheme = (theme: Theme) => {
-  const root = document.documentElement;
+const applySystemResolvedTheme = (theme: Theme) => {
   const resolved = resolveTheme(theme);
-
   useUiStore.getState().setResolvedTheme(resolved);
-
-  if (resolved === 'dark') {
-    root.classList.add('dark');
-  } else {
-    root.classList.remove('dark');
-  }
+  applyResolvedThemeToDocument(resolved);
 };
 
 /**
@@ -33,7 +28,7 @@ const updateTheme = (theme: Theme) => {
 const handleSystemThemeChange = () => {
   const theme = useUiStore.getState().theme;
   if (theme === 'system') {
-    updateTheme(theme);
+    applySystemResolvedTheme(theme);
   }
 };
 
@@ -69,12 +64,6 @@ export function useTheme() {
     // Initialize status bar style (light/dark icons) based on theme
     await initStatusBar();
 
-    // Clean up existing subscription if it exists
-    if (unsubscribeTheme) {
-      unsubscribeTheme();
-      unsubscribeTheme = null;
-    }
-
     // Clean up existing media query listener if it exists
     if (mediaQueryListener && mediaQuery) {
       mediaQuery.removeEventListener('change', mediaQueryListener);
@@ -85,28 +74,20 @@ export function useTheme() {
     // Initialize system theme listener
     initSystemThemeListener();
 
-    // Get current theme from store (not from closure) to ensure we use the latest value
-    const currentTheme = useUiStore.getState().theme;
-    // Apply initial theme
-    updateTheme(currentTheme);
+    // First paint before persist rehydrate may still use default theme; sync DOM once.
+    applySystemResolvedTheme(useUiStore.getState().theme);
 
-    // Subscribe to theme changes from store
-    unsubscribeTheme = useUiStore.subscribe((state, prevState) => {
+    // User theme changes update DOM in uiStore.setTheme. Only re-wire OS listener here.
+    const unsubscribe = useUiStore.subscribe((state, prevState) => {
       if (state.theme !== prevState.theme) {
-        updateTheme(state.theme);
-        // Re-initialize listener when theme changes to/from system
         if (state.theme === 'system' || prevState.theme === 'system') {
           initSystemThemeListener();
         }
       }
     });
 
-    // Return cleanup function
     return () => {
-      if (unsubscribeTheme) {
-        unsubscribeTheme();
-        unsubscribeTheme = null;
-      }
+      unsubscribe();
       if (mediaQueryListener && mediaQuery) {
         mediaQuery.removeEventListener('change', mediaQueryListener);
         mediaQueryListener = null;

--- a/src/stores/uiStore.tsx
+++ b/src/stores/uiStore.tsx
@@ -2,7 +2,10 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { createSelectors } from './utils/createSelectors';
 import { STORAGE_KEYS } from '../utils/localStorage';
-import { resolveTheme } from '../utils/themeUtils';
+import {
+  applyResolvedThemeToDocument,
+  resolveTheme,
+} from '../utils/themeUtils';
 import i18n, { type SupportedLanguage } from '../i18n';
 
 export type Theme = 'light' | 'dark' | 'system';
@@ -40,7 +43,9 @@ const useUiStoreBase = create<UiStoreState>()(
       theme: 'system',
       resolvedTheme: resolveTheme('system'),
       setTheme: (theme: Theme) => {
-        set({ theme });
+        const resolved = resolveTheme(theme);
+        set({ theme, resolvedTheme: resolved });
+        applyResolvedThemeToDocument(resolved);
       },
       setResolvedTheme: (resolvedTheme: 'light' | 'dark') => {
         set({ resolvedTheme });
@@ -85,10 +90,24 @@ const useUiStoreBase = create<UiStoreState>()(
         showBottomNav: state.showBottomNav,
         language: state.language,
       }),
-      onRehydrateStorage: () => state => {
-        if (state?.language && state.language !== i18n.language) {
+      merge: (persistedState, currentState) => {
+        if (!persistedState || typeof persistedState !== 'object') {
+          return currentState;
+        }
+        const p = persistedState as Partial<UiStoreState>;
+        const theme = (p.theme ?? currentState.theme) as Theme;
+        return {
+          ...currentState,
+          ...p,
+          resolvedTheme: resolveTheme(theme),
+        };
+      },
+      onRehydrateStorage: () => (state, error) => {
+        if (error || !state) return;
+        if (state.language && state.language !== i18n.language) {
           i18n.changeLanguage(state.language);
         }
+        applyResolvedThemeToDocument(resolveTheme(state.theme));
       },
     }
   )

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -1,4 +1,4 @@
-import { Theme, ResolvedTheme } from '../stores/uiStore';
+import type { Theme, ResolvedTheme } from '../stores/uiStore';
 
 /**
  * Resolves a theme value to either 'light' or 'dark'.
@@ -12,4 +12,10 @@ export function resolveTheme(theme: Theme): ResolvedTheme {
       : 'light';
   }
   return theme;
+}
+
+/** Applies resolved theme to <html> (Tailwind `dark` + CSS variables in theme.css). */
+export function applyResolvedThemeToDocument(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
 }


### PR DESCRIPTION
## Résumé
Le choix de thème (clair / sombre / système) ne mettait pas toujours à jour le DOM ni `resolvedTheme` après rechargement.

## Changements
- `setTheme` met à jour `theme`, `resolvedTheme` et la classe `dark` sur `<html>`.
- `merge` du store persisté pour recalculer `resolvedTheme` à partir du thème stocké.
- `onRehydrateStorage` : application du thème au document après hydratation.
- Extraction de `applyResolvedThemeToDocument` dans `themeUtils`.

## Tests
- Réglages → Apparence : basculer les thèmes et recharger la page.