### PR TITLE
feat(ui): retour tactile des lignes interactives (.hover-fill)

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -209,39 +209,37 @@
     transform-origin: center;
   }
 
-  /* Hover fill effect — spreads from center horizontally.
-     Usage: add .hover-fill to a parent with position:relative + overflow:hidden.
-     The pseudo-element handles the animation automatically.
-     Customize color with --hover-fill-color (default: accent/50). */
+  /* Hover / press: léger mouvement seulement (pas de voile / couleur).
+     Survol = lift discret; press = léger enfoncement. (hover: hover) évite le double-tap iOS. */
   .hover-fill {
     position: relative;
     overflow: hidden;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  .hover-fill::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background-color: var(
-      --hover-fill-color,
-      color-mix(in oklch, var(--color-accent) 50%, transparent)
-    );
-    transform: scaleX(0);
-    transform-origin: center;
-    transition: transform 0ms;
-    pointer-events: none;
+  @media (hover: hover) {
+    .hover-fill:hover:not(:active) {
+      transform: translateY(-1px);
+    }
+
+    .hover-fill:active {
+      transform: scale(0.98);
+    }
   }
 
-  .hover-fill:hover::before {
-    transform: scaleX(1);
-    transition: transform 150ms cubic-bezier(0.1, 0.6, 0.3, 1);
+  @media (hover: none) {
+    .hover-fill:active {
+      transform: scale(0.97);
+    }
   }
 
-  .hover-fill:active::before {
-    background-color: var(
-      --hover-fill-active-color,
-      color-mix(in oklch, var(--color-accent) 70%, transparent)
-    );
+  @media (prefers-reduced-motion: reduce) {
+    .hover-fill {
+      transition-duration: 0.01ms !important;
+      transform: none !important;
+    }
   }
 
   /* Animated counter keyframes */


### PR DESCRIPTION
## Résumé
Ajustement du feedback visuel des éléments `.hover-fill` (listes, menus, réglages).

## Changements
- Suppression du calque coloré ; léger déplacement vertical au survol et léger scale au press sur tactile.
- `touch-action: manipulation` et `@media (hover: hover)` pour limiter le double tap iOS.
- Respect de `prefers-reduced-motion`.