### PR TITLE
chore(scripts): détection des appareils iOS (dev-scan / dev-ios)

### DIFF
--- a/scripts/dev-all.sh
+++ b/scripts/dev-all.sh
@@ -2,6 +2,9 @@
 #
 # Live reload on multiple Android and iOS devices simultaneously.
 #
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export GOSSIP_REPO_ROOT="$REPO_ROOT"
+#
 # Device lists can be set via env vars (comma-separated) or CLI args.
 # Env vars take precedence over CLI args.
 #
@@ -12,6 +15,9 @@
 # Usage (CLI fallback):
 #   scripts/dev-all.sh <android-device> [ios-device]
 #
+# Optional:
+#   DEV_ALL_QUIET=1  Less Vite noise (warn+); npm build:sdk stays verbose unless you use npm -s yourself.
+#
 # Examples:
 #   # Using env vars (recommended for multi-device):
 #   ANDROID_DEVICES="10.26.239.15:5555,10.26.239.20:5555" scripts/dev-all.sh
@@ -19,6 +25,9 @@
 #   # Using CLI args (single device each, backwards-compatible):
 #   scripts/dev-all.sh 10.26.239.15:5555 "iPhone de Ben"
 #   scripts/dev-all.sh 10.26.239.15:5555   # iOS opens Xcode
+
+# Fallback iOS deploy when Capacitor/native-run does not list Wi‑Fi devices
+. "$(dirname "${BASH_SOURCE[0]}")/ios-deploy-fallback.sh"
 
 # Read a var from .env safely (handles special chars like apostrophes)
 read_env() {
@@ -128,7 +137,9 @@ wait
 
 # Start Vite dev server in background, wait for it to be ready
 echo "[dev-all] Starting Vite dev server..."
-npx vite --host &
+VITE_ARGS=(--host)
+[ "${DEV_ALL_QUIET:-}" = 1 ] && VITE_ARGS+=(--logLevel warn)
+npx vite "${VITE_ARGS[@]}" &
 VITE_PID=$!
 
 # Wait for Vite to be ready
@@ -169,7 +180,11 @@ deploy_ios() {
   if [ ${#IOSES[@]} -gt 0 ]; then
     for device in "${IOSES[@]}"; do
       echo "[dev-all] Building + deploying to iOS: ${device}..."
-      npx cap run ios --target "$device" --no-sync || echo "[dev-all] WARNING: iOS deploy failed for ${device}"
+      if npx cap run ios --target "$device" --no-sync; then
+        :
+      else
+        deploy_ios_xcode_fallback "$device" || echo "[dev-all] WARNING: iOS deploy failed for ${device}"
+      fi
     done
   else
     echo "[dev-all] No iOS devices specified, opening Xcode..."

--- a/scripts/dev-ios.sh
+++ b/scripts/dev-ios.sh
@@ -25,6 +25,11 @@
 
 set -e
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export GOSSIP_REPO_ROOT="$REPO_ROOT"
+
+. "$(dirname "${BASH_SOURCE[0]}")/ios-deploy-fallback.sh"
+
 DEVICE="$1"
 
 if [ -z "$DEVICE" ]; then
@@ -72,7 +77,9 @@ npx cap sync ios
 # Deploy to device
 echo "[dev-ios] Deploying to device..."
 echo "[dev-ios] Target device: ${DEVICE}"
-npx cap run ios --target "$DEVICE"
+if ! npx cap run ios --target "$DEVICE"; then
+  deploy_ios_xcode_fallback "$DEVICE" || exit 1
+fi
 
 # Start Vite dev server (foreground — Ctrl+C to stop)
 echo ""

--- a/scripts/dev-scan.sh
+++ b/scripts/dev-scan.sh
@@ -23,17 +23,43 @@ fi
 
 echo ""
 
-# --- iOS: connected devices (via Capacitor) ---
+# --- iOS: connected devices (via xctrace, then Capacitor fallback) ---
 IOS_LIST=()
-while IFS= read -r line; do
-  [ -z "$line" ] && continue
-  udid=$(echo "$line" | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}')
-  [ -z "$udid" ] && continue
-  echo "$line" | grep -qi 'simulator' && continue
-  name=$(echo "$line" | awk -F'  +' '{print $1}' | xargs)
-  echo "  iOS: ${name}  (${udid})"
-  IOS_LIST+=("$udid")
-done < <(npx cap run ios --list 2>/dev/null | tail -n +3)
+
+# Try xcrun xctrace first — detects both USB and WiFi-connected devices
+if command -v xcrun &>/dev/null; then
+  in_devices=false
+  while IFS= read -r line; do
+    if echo "$line" | grep -q '^== Devices ==$'; then
+      in_devices=true; continue
+    fi
+    if echo "$line" | grep -q '^=='; then
+      in_devices=false; continue
+    fi
+    $in_devices || continue
+    echo "$line" | grep -qi 'simulator' && continue
+    echo "$line" | grep -qi 'macbook\|mac pro\|mac mini\|imac\|mac studio' && continue
+    [ -z "$line" ] && continue
+    udid=$(echo "$line" | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}')
+    [ -z "$udid" ] && continue
+    name=$(echo "$line" | sed 's/ ([^)]*) *$//' | xargs)
+    echo "  iOS: ${name}  (${udid})"
+    IOS_LIST+=("$udid")
+  done < <(xcrun xctrace list devices 2>/dev/null)
+fi
+
+# Fallback to Capacitor if xctrace found nothing
+if [ ${#IOS_LIST[@]} -eq 0 ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    udid=$(echo "$line" | grep -oE '[0-9A-Fa-f]{8}-[0-9A-Fa-f]{16}')
+    [ -z "$udid" ] && continue
+    echo "$line" | grep -qi 'simulator' && continue
+    name=$(echo "$line" | awk -F'  +' '{print $1}' | xargs)
+    echo "  iOS: ${name}  (${udid})"
+    IOS_LIST+=("$udid")
+  done < <(npx cap run ios --list 2>/dev/null | tail -n +3)
+fi
 
 echo ""
 echo "--- Paste into .env ---"


### PR DESCRIPTION
## Résumé
Amélioration de la liste des appareils iOS pour les scripts de développement.

## Changements
- `dev-scan.sh` : liste via `xcrun xctrace list devices` (USB / Wi‑Fi), repli sur `npx cap run ios --list`.
- Alignement des scripts `dev-all` / `dev-ios` associés.

Made with [Cursor](https://cursor.com)