### PR TITLE
fix(messages): menu contextuel après plusieurs clics droit (PC)

### DIFF
--- a/src/components/discussions/MessageItem.tsx
+++ b/src/components/discussions/MessageItem.tsx
@@ -284,9 +284,17 @@ const MessageItem: React.FC<MessageItemProps> = ({
         // Don't prevent default — let native selection handles appear
         return;
       }
+      e.preventDefault();
+      // Desktop / web: open the same actions menu as a bubble click (no touch long-press state).
+      // If a touch long-press just ran, skip — iOS can emit a synthetic contextmenu and we must
+      // not open the menu twice (same as longPress.onContextMenu duplicate guard).
+      if (!isAndroid && !isSelecting && !longPress.longPressTriggered.current) {
+        openContextMenu();
+        return;
+      }
       longPress.onContextMenu(e);
     },
-    [isAndroid, longPress, isDeleted]
+    [isAndroid, longPress, isDeleted, isSelecting, openContextMenu]
   );
   // Context menu items — depend on stable scalars, not the full message object
   const contextMenuItems = useMemo<MessageContextMenuItem[]>(() => {

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -84,9 +84,13 @@ export function useLongPress({
     (e: React.MouseEvent) => {
       if (disabled) return;
       e.preventDefault();
+      // Skip duplicate when touch long-press already fired (timer + contextmenu on Android).
       if (longPressTriggered.current) return;
       longPressTriggered.current = true;
       onLongPress();
+      // Touch resets this in onTouchStart; mouse-only contextmenu never does — reset so the
+      // next right-click on the same element works (desktop).
+      longPressTriggered.current = false;
     },
     [disabled, onLongPress]
   );

--- a/test/hooks/useLongPress.browser.spec.tsx
+++ b/test/hooks/useLongPress.browser.spec.tsx
@@ -135,6 +135,23 @@ describe('useLongPress', () => {
     expect(defaultPrevented).toBe(true);
   });
 
+  it('triggers again on a second right-click (mouse has no touchstart reset)', async () => {
+    const onLongPress = vi.fn();
+    render(<TestComponent onLongPress={onLongPress} />);
+
+    const target = page.getByTestId('target');
+    const el = target.element() as HTMLElement;
+
+    el.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    );
+    el.dispatchEvent(
+      new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+    );
+
+    expect(onLongPress).toHaveBeenCalledTimes(2);
+  });
+
   it('does nothing when disabled', async () => {
     const onLongPress = vi.fn();
     render(<TestComponent onLongPress={onLongPress} delay={100} disabled />);


### PR DESCRIPTION
## Problème
Sur PC, un premier clic droit sur un message ouvrait le menu, les suivants sur le même message ne faisaient plus rien.

## Cause
`useLongPress` laissait `longPressTriggered` à `true` après `contextmenu` souris (aucun `touchstart` pour réinitialiser, contrairement au tactile).

## Correctifs
- **useLongPress** : remise à `false` de `longPressTriggered` après traitement d’un `contextmenu` souris (le doublon timer + `contextmenu` Android reste ignoré).
- **MessageItem** : sur web hors Android, hors mode sélection, ouverture du menu comme le clic sur la bulle, sans passer par le long press **sauf** si un long press tactile vient d’être traité (évite une double ouverture sur iOS).

## Test
- `useLongPress` : deux `contextmenu` consécutifs → deux callbacks.

## Vérification
`vitest run test/hooks/useLongPress.browser.spec.tsx test/components/discussions/MessageItem.browser.spec.tsx` : OK.