### PR TITLE
fix(share): un seul bouton en chargement lors du partage QR

### DIFF
--- a/src/components/settings/ShareContact.tsx
+++ b/src/components/settings/ShareContact.tsx
@@ -37,7 +37,8 @@ const ShareContact: React.FC<ShareContactProps> = ({
 }) => {
   const { t } = useTranslation('contacts');
   // Note: we keep a single QR/file-sharing view for now, no tab switcher.
-  const { qrDataUrl, setQrDataUrl, isSharingQR, handleShareQR } = useQRShare();
+  const { qrDataUrl, setQrDataUrl, isSharingQR, qrShareSource, handleShareQR } =
+    useQRShare();
   const [isFilePanelOpen, setIsFilePanelOpen] = useState(false);
   const [includeUsername, setIncludeUsername] = useState(true);
   const [sharedUsername, setSharedUsername] = useState(userName);
@@ -137,11 +138,17 @@ const ShareContact: React.FC<ShareContactProps> = ({
             variant="outline"
             size="custom"
             className="h-11 flex items-center justify-center gap-2 rounded-xl"
-            onClick={canShareViaOtherApp ? handleShareLink : handleShareQR}
+            onClick={
+              canShareViaOtherApp
+                ? handleShareLink
+                : () => void handleShareQR('share')
+            }
             disabled={
               canShareViaOtherApp ? isSharingLink : !qrDataUrl || isSharingQR
             }
-            loading={isSharingLink || isSharingQR}
+            loading={
+              canShareViaOtherApp ? isSharingLink : qrShareSource === 'share'
+            }
           >
             <Send className="w-4 h-4" />
             <span className="text-sm font-normal">Share</span>
@@ -151,9 +158,9 @@ const ShareContact: React.FC<ShareContactProps> = ({
             variant="outline"
             size="custom"
             className="h-11 flex items-center justify-center gap-2 rounded-xl"
-            onClick={handleShareQR}
+            onClick={() => void handleShareQR('qr')}
             disabled={!qrDataUrl || isSharingQR}
-            loading={isSharingQR}
+            loading={qrShareSource === 'qr'}
           >
             <Image className="w-4 h-4" />
             <span className="text-sm font-normal">QR</span>

--- a/src/hooks/useQRShare.ts
+++ b/src/hooks/useQRShare.ts
@@ -2,31 +2,48 @@ import { useState, useCallback } from 'react';
 import toast from 'react-hot-toast';
 import { shareQRCode } from '../services/shareService';
 
+/** Which grid button triggered the share (so only that button shows loading). */
+export type QrShareSource = 'share' | 'qr';
+
 export function useQRShare(): {
   qrDataUrl: string | null;
   setQrDataUrl: (url: string | null) => void;
+  /** True while a QR share is in progress (either button). */
   isSharingQR: boolean;
-  handleShareQR: () => Promise<void>;
+  /** Which button is currently sharing, or null. */
+  qrShareSource: QrShareSource | null;
+  handleShareQR: (source: QrShareSource) => Promise<void>;
 } {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
-  const [isSharingQR, setIsSharingQR] = useState(false);
+  const [qrShareSource, setQrShareSource] = useState<QrShareSource | null>(
+    null
+  );
 
-  const handleShareQR = useCallback(async () => {
-    if (!qrDataUrl) return;
+  const handleShareQR = useCallback(
+    async (source: QrShareSource) => {
+      if (!qrDataUrl) return;
 
-    try {
-      setIsSharingQR(true);
-      await shareQRCode({
-        qrDataUrl,
-        fileName: 'contact-qr-code.png',
-      });
-    } catch (error) {
-      console.error('Failed to share QR code:', error);
-      toast.error('Failed to share QR code. Please try again.');
-    } finally {
-      setIsSharingQR(false);
-    }
-  }, [qrDataUrl]);
+      try {
+        setQrShareSource(source);
+        await shareQRCode({
+          qrDataUrl,
+          fileName: 'contact-qr-code.png',
+        });
+      } catch (error) {
+        console.error('Failed to share QR code:', error);
+        toast.error('Failed to share QR code. Please try again.');
+      } finally {
+        setQrShareSource(null);
+      }
+    },
+    [qrDataUrl]
+  );
 
-  return { qrDataUrl, setQrDataUrl, isSharingQR, handleShareQR };
+  return {
+    qrDataUrl,
+    setQrDataUrl,
+    isSharingQR: qrShareSource !== null,
+    qrShareSource,
+    handleShareQR,
+  };
 }

--- a/src/i18n/locales/en/discussions.json
+++ b/src/i18n/locales/en/discussions.json
@@ -164,5 +164,5 @@
   "filter_label": "Filter discussions",
   "waiting_connection": "Waiting for connection...",
   "announcement": "Announcement",
-  "lock_account": "Lock Account"
+  "lock_account": "Lock account"
 }

--- a/test/hooks/useQRShare.spec.ts
+++ b/test/hooks/useQRShare.spec.ts
@@ -65,7 +65,7 @@ describe('useQRShare', () => {
     expect(ref.current!.qrDataUrl).toBeNull();
 
     await act(async () => {
-      await ref.current!.handleShareQR();
+      await ref.current!.handleShareQR('share');
     });
 
     expect(mockShareQRCode).not.toHaveBeenCalled();
@@ -80,7 +80,7 @@ describe('useQRShare', () => {
     });
 
     await act(async () => {
-      await ref.current!.handleShareQR();
+      await ref.current!.handleShareQR('share');
     });
 
     expect(mockShareQRCode).toHaveBeenCalledOnce();
@@ -107,7 +107,7 @@ describe('useQRShare', () => {
     let shareResolved = false;
     let shareCallPromise!: Promise<void>;
     act(() => {
-      shareCallPromise = ref.current!.handleShareQR();
+      shareCallPromise = ref.current!.handleShareQR('share');
       shareCallPromise.then(() => {
         shareResolved = true;
       });
@@ -116,6 +116,7 @@ describe('useQRShare', () => {
     // At this point shareQRCode has been called and is pending;
     // isSharingQR should be true
     expect(ref.current!.isSharingQR).toBe(true);
+    expect(ref.current!.qrShareSource).toBe('share');
 
     // Resolve and wait for cleanup
     await act(async () => {
@@ -136,7 +137,7 @@ describe('useQRShare', () => {
     });
 
     await act(async () => {
-      await ref.current!.handleShareQR();
+      await ref.current!.handleShareQR('qr');
     });
 
     expect(mockToastError).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Problème
Lors du partage du QR, les deux boutons (Share et QR) passaient en état chargement.

## Solution
- `useQRShare` : `handleShareQR('share' | 'qr')` et `qrShareSource` pour savoir quel bouton a lancé le partage.
- `ShareContact` : `loading` séparé — `qrShareSource === 'share'` vs `'qr'` ; avec partage système, `isSharingLink` inchangé.

## i18n
- `en/discussions.json` : `lock_account` → « Lock account » (aligné avec les réglages).

## Tests
`vitest run test/hooks/useQRShare.spec.ts test/i18n/missingKeys.node.spec.ts` : OK.