### PR TITLE
fix(sdk): copy WASM-returned Uint8Arrays at the bridge

### DIFF
--- a/gossip-sdk/src/wasm/session.ts
+++ b/gossip-sdk/src/wasm/session.ts
@@ -3,13 +3,18 @@
  *
  * This file contains the real WASM implementation of the SessionModule
  * using SessionManagerWrapper and related WASM classes.
+ *
+ * All Uint8Array values returned from WASM are funneled through `copyOut` /
+ * `copyOutMany` so callers always get JS-owned buffers. Without this, a
+ * subsequent WASM allocation that grows linear memory detaches the original
+ * `wasm.memory.buffer` and any Uint8Array view sitting on top of it — leading
+ * to "detached ArrayBuffer" failures on the next read.
  */
 
 import {
   SessionManagerWrapper,
   UserPublicKeys,
   UserSecretKeys,
-  ReceiveMessageOutput,
   SendMessageOutput,
   SessionStatus,
   EncryptionKey,
@@ -18,6 +23,16 @@ import {
   UserKeys,
 } from './bindings.js';
 import { encodeUserId } from '../utils/userId.js';
+
+const copyOut = (a: Uint8Array): Uint8Array => new Uint8Array(a);
+const copyOutMany = (xs: Uint8Array[]): Uint8Array[] => xs.map(copyOut);
+
+export interface ReceivedMessage {
+  message: Uint8Array;
+  user_id: Uint8Array;
+  timestamp: number;
+  acknowledged_seekers: Uint8Array[];
+}
 
 export class SessionModule {
   private sessionManager: SessionManagerWrapper | null = null;
@@ -34,7 +49,7 @@ export class SessionModule {
   ) {
     this.ourPk = userKeys.public_keys();
     this.ourSk = userKeys.secret_keys();
-    this.userId = this.ourPk.derive_id();
+    this.userId = copyOut(this.ourPk.derive_id());
     this.userIdEncoded = encodeUserId(this.userId);
 
     const sessionConfig = config ?? SessionConfig.new_default();
@@ -98,7 +113,7 @@ export class SessionModule {
       throw new Error('Session manager is not initialized');
     }
 
-    return this.sessionManager.to_encrypted_blob(key);
+    return copyOut(this.sessionManager.to_encrypted_blob(key));
   }
 
   cleanup(): void {
@@ -121,11 +136,13 @@ export class SessionModule {
     }
 
     const userDataBytes = userData ?? new Uint8Array(0);
-    const result = this.sessionManager.establish_outgoing_session(
-      peerPk,
-      this.ourPk,
-      this.ourSk,
-      userDataBytes
+    const result = copyOut(
+      this.sessionManager.establish_outgoing_session(
+        peerPk,
+        this.ourPk,
+        this.ourSk,
+        userDataBytes
+      )
     );
 
     if (result.length === 0) {
@@ -169,7 +186,7 @@ export class SessionModule {
       throw new Error('Session manager is not initialized');
     }
 
-    return this.sessionManager.get_message_board_read_keys();
+    return copyOutMany(this.sessionManager.get_message_board_read_keys());
   }
 
   /**
@@ -178,7 +195,7 @@ export class SessionModule {
   async feedIncomingMessageBoardRead(
     seeker: Uint8Array,
     ciphertext: Uint8Array
-  ): Promise<ReceiveMessageOutput | undefined> {
+  ): Promise<ReceivedMessage | undefined> {
     if (!this.sessionManager) {
       throw new Error('Session manager is not initialized');
     }
@@ -188,9 +205,24 @@ export class SessionModule {
       ciphertext,
       this.ourSk
     );
+    if (!result) {
+      return undefined;
+    }
+
+    // Snapshot before any further WASM activity (persistIfNeeded / scheduler
+    // yields) can grow linear memory and detach views.
+    const snapshot: ReceivedMessage = {
+      message: copyOut(result.message),
+      user_id: copyOut(result.user_id),
+      timestamp: result.timestamp,
+      acknowledged_seekers: copyOutMany(
+        result.acknowledged_seekers as Uint8Array[]
+      ),
+    };
+    result.free();
 
     await this.persistIfNeeded();
-    return result;
+    return snapshot;
   }
 
   /**
@@ -221,7 +253,7 @@ export class SessionModule {
       throw new Error('Session manager is not initialized');
     }
 
-    return this.sessionManager.peer_list();
+    return copyOutMany(this.sessionManager.peer_list());
   }
 
   /**
@@ -255,7 +287,7 @@ export class SessionModule {
       throw new Error('Session manager is not initialized');
     }
 
-    const result = this.sessionManager.refresh();
+    const result = copyOutMany(this.sessionManager.refresh());
     await this.persistIfNeeded();
     return result;
   }


### PR DESCRIPTION
## Summary

- Funnel every \`Uint8Array\` / \`Uint8Array[]\` return from the session WASM bridge through \`copyOut\` / \`copyOutMany\` so consumers get JS-owned buffers instead of views into \`wasm.memory.buffer\`.
- Replace the \`ReceiveMessageOutput\` WASM wrapper at the bridge boundary with a \`ReceivedMessage\` POJO; snapshot all fields immediately and free the wrapper before the persist \`await\`.
- Restore the single source of truth in the bridge so service callers don't need defensive copies.

## Why

Subscribers of \`SEEKERS_UPDATED\` were intermittently hitting:

\`\`\`
TypeError: Cannot perform %TypedArray%.prototype.values on a detached or out-of-bounds ArrayBuffer
\`\`\`

at \`src/services/index.ts:35\` (\`seekers.map(s => Array.from(s))\`). Tracing back, \`session.getMessageBoardReadKeys()\` returned WASM-backed \`Uint8Array\`s. Any later WASM call that grew linear memory — increasingly likely since:

- #514 introduced EVM keypair derivation (heavy crypto allocations during \`refresh\` / \`openSession\`),
- the SQLite worker migration (#414, #632) widened the \`await\` between seeker fetch and emit,
- optimistic UI changes (#588, #623) parallelised announcement/refresh work,

— would detach \`wasm.memory.buffer\` and any view sitting on it. The race was latent since Feb 2026 (PRs #378 + #414); recent allocator-heavy work made it surface.

## What changed

\`gossip-sdk/src/wasm/session.ts\` only:

| Method | Before | After |
|---|---|---|
| \`userId\` (constructor) | view of WASM mem | \`copyOut\` |
| \`toEncryptedBlob\` | direct return | \`copyOut\` |
| \`establishOutgoingSession\` | direct return | \`copyOut\` |
| \`getMessageBoardReadKeys\` | array of WASM views | \`copyOutMany\` |
| \`peerList\` | array of WASM views | \`copyOutMany\` |
| \`refresh\` | array of WASM views | \`copyOutMany\` |
| \`feedIncomingMessageBoardRead\` | \`ReceiveMessageOutput\` wrapper | \`ReceivedMessage\` POJO + \`result.free()\` |

\`SendMessageOutput.{data,seeker}\`, \`AnnouncementResult.user_data\`, \`ReceiveMessageOutput.{message,user_id}\` already \`.slice()\` their bytes in the generated bindings — left as-is.

## Cost

A single \`new Uint8Array(bytes)\` per WASM return; the original (already-WASM-or-already-copied) is GC'd. Net steady-state: same. Surcoût: ≪ 1 KB at any given time on small payloads (seekers/peer IDs are 32 B).

## Alternatives considered

- **Pre-allocate \`maximum\` WASM memory upfront**: replaces a silent crash with a loud OOM on mobile, magic constant.
- **Switch to \`SharedArrayBuffer\`**: requires COOP/COEP — already ruled out for the project.
- **Rust-side \`&mut [u8]\` out-params (Damir's pattern)**: cleanest at the source for fixed-size returns (peer IDs, seekers), but variable-size blobs (\`to_encrypted_blob\`, \`establish_outgoing_session\`) don't fit. Worth a follow-up for the fixed-size sites; this PR keeps the defense uniform in TS without a WASM rebuild.

## Test plan

- [x] \`npm run fmt\`
- [x] \`npm test\` (app: 499 passing)
- [x] \`cd gossip-sdk && npm test\` (309 passing)
- [x] \`tsc --noEmit\` clean
- [ ] **Manual repro**: log in, let polling run a few cycles, confirm no \`SEEKERS_UPDATED\` detached-buffer error in the console