### PR TITLE
Do not skip announcement history on mnemonic restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # rust stuff
 target/
 wasm/target
-
+dzeojdzd
 # coverage
 coverage/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # rust stuff
 target/
 wasm/target
-dzeojdzd
+
 # coverage
 coverage/
 

--- a/src/stores/accountStore.tsx
+++ b/src/stores/accountStore.tsx
@@ -419,9 +419,6 @@ const useAccountStoreBase = create<AccountState>((set, get) => {
           session
         );
 
-        // Skip historical announcements AFTER profile is persisted
-        await getSdk().announcements.skipHistorical();
-
         useAppStore.getState().setIsInitialized(true);
         set({
           account,


### PR DESCRIPTION
## Summary
- `restoreAccountFromMnemonic` was calling `announcements.skipHistorical()`, which set the cursor to the latest bulletin counter and prevented the user from receiving any past announcements after restore.
- Restoring from a mnemonic means the user is recovering an existing identity, so the full announcement history must be fetched. Skipping is only correct for brand-new accounts.
- Removed the `skipHistorical()` call from the mnemonic restore path. `initializeAccount` and `initializeAccountWithBiometrics` still skip history, which is the intended behavior for new accounts.

## Test plan
- [ ] Restore an account from a mnemonic on a fresh device and verify past announcements are received
- [ ] Create a new account (password) and verify history is skipped (no flood of old announcements)
- [ ] Create a new account (biometrics) and verify history is skipped