### PR TITLE
fix(share): avoid URL duplication on Android and embed URL on web

### DIFF
--- a/src/services/shareService.ts
+++ b/src/services/shareService.ts
@@ -184,15 +184,19 @@ export async function shareInvitation(
   // Use native Capacitor Share plugin on native platforms
   if (Capacitor.isNativePlatform()) {
     try {
-      // Pass both `text` (with URL embedded) AND `url` separately:
-      // - `url` is what modern Telegram/iMessage use to validate a shareable
-      //   link — without it they may gray out the Send button.
-      // - Embedding the URL in `text` covers the older apps that ignore the
-      //   separate `url` field and only paste whatever's in `text`.
+      const isAndroid = Capacitor.getPlatform() === 'android';
+      const text = shareText ? `${shareText}\n${deepLinkUrl}` : deepLinkUrl;
+      // On Android, ACTION_SEND only carries EXTRA_TEXT and the Capacitor
+      // plugin concatenates `text + " " + url`, which duplicates the URL and
+      // confuses some apps (Telegram in particular). Embed the URL in `text`
+      // and omit `url`.
+      // On iOS, UIActivityViewController exposes them as separate items;
+      // some apps use only `text`, others only `url`, so pass both (the
+      // duplicated URL is harmless because the receiving app picks one item).
       await Share.share({
         title: shareTitle,
-        text: shareText ? `${shareText}\n${deepLinkUrl}` : deepLinkUrl,
-        url: deepLinkUrl,
+        text,
+        ...(isAndroid ? {} : { url: deepLinkUrl }),
         dialogTitle: shareTitle,
       });
       return;
@@ -205,9 +209,12 @@ export async function shareInvitation(
   // Use Web Share API on web platforms
   if (typeof navigator !== 'undefined' && navigator.share) {
     try {
+      // Mirror the native path: embed the URL in `text` AND pass `url`
+      // separately. Telegram's web share target ignores the `url` field
+      // and only pastes `text`, so without embedding the link is lost.
       await navigator.share({
         title: shareTitle,
-        text: shareText,
+        text: shareText ? `${shareText}\n${deepLinkUrl}` : deepLinkUrl,
         url: deepLinkUrl,
       });
       return;


### PR DESCRIPTION
## Summary
- On Android, the Capacitor Share plugin concatenates `text + " " + url` into `EXTRA_TEXT`, which duplicated our invite URL and intermittently broke sharing to Telegram (grayed-out Send button, can't send / can't go back).
- Pass only `text` (with the URL embedded) on Android; keep both `text` and `url` on iOS since `UIActivityViewController` exposes them as distinct items and apps pick one.
- On the Web Share API path, Telegram's web share target only reads `text` and ignores `url`, so the invite link was being lost. Mirror the native pattern: embed the URL in `text` and still pass `url` for apps that prefer it.

## Test plan
- [ ] Android APK: share contact → pick Telegram → message pre-fills with text + single URL, Send is enabled
- [ ] Android APK: share contact → other apps (WhatsApp, SMS, Gmail) still receive a clean message
- [ ] iOS native: share contact → Telegram, iMessage, Mail all behave as before (both text and URL passed)
- [ ] Safari iOS web: share contact → pick Telegram → URL is included in the pre-filled message
- [ ] Desktop fallback: clipboard copy still works when Web Share API isn't available