### PR TITLE
Fix file sharing on telegram

### DIFF
--- a/src/services/shareService.ts
+++ b/src/services/shareService.ts
@@ -55,17 +55,30 @@ function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
+function uniqueNativeShareFileName(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf('.');
+  const base = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName;
+  const extension = dotIndex > 0 ? fileName.slice(dotIndex) : '';
+  const suffix =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  return `${base}-${suffix}${extension}`;
+}
+
 async function shareFileViaNative(
   blob: Blob,
   fileName: string,
   title: string
 ): Promise<void> {
   const base64Data = await blobToBase64(blob);
+  const cacheFileName = uniqueNativeShareFileName(fileName);
 
   let shouldCleanup = false;
   try {
     const { uri } = await Filesystem.writeFile({
-      path: fileName,
+      path: cacheFileName,
       data: base64Data,
       directory: Directory.Cache,
     });
@@ -81,7 +94,7 @@ async function shareFileViaNative(
       setTimeout(async () => {
         try {
           await Filesystem.deleteFile({
-            path: fileName,
+            path: cacheFileName,
             directory: Directory.Cache,
           });
         } catch {

--- a/src/services/shareService.ts
+++ b/src/services/shareService.ts
@@ -23,6 +23,8 @@ export interface ShareFileOptions {
   mimeType?: string;
 }
 
+const NATIVE_SHARE_FILE_CLEANUP_DELAY_MS = 60_000;
+
 function isShareCancellation(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -60,12 +62,14 @@ async function shareFileViaNative(
 ): Promise<void> {
   const base64Data = await blobToBase64(blob);
 
+  let shouldCleanup = false;
   try {
     const { uri } = await Filesystem.writeFile({
       path: fileName,
       data: base64Data,
       directory: Directory.Cache,
     });
+    shouldCleanup = true;
 
     await Share.share({
       title,
@@ -73,13 +77,17 @@ async function shareFileViaNative(
       dialogTitle: title,
     });
   } finally {
-    try {
-      await Filesystem.deleteFile({
-        path: fileName,
-        directory: Directory.Cache,
-      });
-    } catch {
-      // File cleanup is best effort
+    if (shouldCleanup) {
+      setTimeout(async () => {
+        try {
+          await Filesystem.deleteFile({
+            path: fileName,
+            directory: Directory.Cache,
+          });
+        } catch {
+          // File cleanup is best effort
+        }
+      }, NATIVE_SHARE_FILE_CLEANUP_DELAY_MS);
     }
   }
 }

--- a/test/services/shareService.test.ts
+++ b/test/services/shareService.test.ts
@@ -54,7 +54,9 @@ beforeEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   mockIsNative.mockReturnValue(false);
-  mockWriteFile.mockResolvedValue({ uri: 'file:///cache/contact-qr-code.png' });
+  mockWriteFile.mockImplementation(async ({ path }) => ({
+    uri: `file:///cache/${path}`,
+  }));
   mockDeleteFile.mockResolvedValue(undefined);
   setNavigatorShare(undefined);
   setClipboard(vi.fn().mockResolvedValue(undefined));
@@ -171,14 +173,15 @@ describe('shareFile', () => {
         title: 'Gossip QR Code',
       });
 
+      const cacheFileName = mockWriteFile.mock.calls[0][0].path;
       expect(mockWriteFile).toHaveBeenCalledWith({
-        path: 'contact-qr-code.png',
+        path: cacheFileName,
         data: expect.any(String),
         directory: Directory.Cache,
       });
       expect(mockShare).toHaveBeenCalledWith({
         title: 'Gossip QR Code',
-        files: ['file:///cache/contact-qr-code.png'],
+        files: [`file:///cache/${cacheFileName}`],
         dialogTitle: 'Gossip QR Code',
       });
       expect(mockDeleteFile).not.toHaveBeenCalled();
@@ -186,7 +189,7 @@ describe('shareFile', () => {
       await vi.runAllTimersAsync();
 
       expect(mockDeleteFile).toHaveBeenCalledWith({
-        path: 'contact-qr-code.png',
+        path: cacheFileName,
         directory: Directory.Cache,
       });
     });

--- a/test/services/shareService.test.ts
+++ b/test/services/shareService.test.ts
@@ -14,16 +14,24 @@ vi.mock('@capacitor/share', () => ({
 }));
 
 vi.mock('@capacitor/filesystem', () => ({
-  Filesystem: {},
-  Directory: {},
+  Filesystem: {
+    writeFile: vi.fn(),
+    deleteFile: vi.fn(),
+  },
+  Directory: {
+    Cache: 'CACHE',
+  },
 }));
 
-import { shareMessage } from '../../src/services/shareService';
+import { shareFile, shareMessage } from '../../src/services/shareService';
 import { Capacitor } from '@capacitor/core';
 import { Share } from '@capacitor/share';
+import { Filesystem, Directory } from '@capacitor/filesystem';
 
 const mockIsNative = vi.mocked(Capacitor.isNativePlatform);
 const mockShare = vi.mocked(Share.share);
+const mockWriteFile = vi.mocked(Filesystem.writeFile);
+const mockDeleteFile = vi.mocked(Filesystem.deleteFile);
 
 function setNavigatorShare(fn: typeof navigator.share | undefined) {
   Object.defineProperty(navigator, 'share', {
@@ -43,7 +51,11 @@ function setClipboard(writeText: (text: string) => Promise<void>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
   mockIsNative.mockReturnValue(false);
+  mockWriteFile.mockResolvedValue({ uri: 'file:///cache/contact-qr-code.png' });
+  mockDeleteFile.mockResolvedValue(undefined);
   setNavigatorShare(undefined);
   setClipboard(vi.fn().mockResolvedValue(undefined));
 });
@@ -127,6 +139,107 @@ describe('shareMessage', () => {
     it('throws when clipboard also fails', async () => {
       setClipboard(vi.fn().mockRejectedValue(new Error('Clipboard denied')));
       await expect(shareMessage('Hello')).rejects.toThrow('Clipboard denied');
+    });
+  });
+});
+
+describe('shareFile', () => {
+  describe('native platform (iOS/Android)', () => {
+    beforeEach(() => {
+      mockIsNative.mockReturnValue(true);
+    });
+
+    it('keeps the cached file available briefly after native share resolves', async () => {
+      vi.useFakeTimers();
+      vi.stubGlobal(
+        'FileReader',
+        class {
+          result = 'data:image/png;base64,cG5n';
+          onloadend: (() => void) | null = null;
+          onerror: (() => void) | null = null;
+
+          readAsDataURL() {
+            this.onloadend?.();
+          }
+        }
+      );
+      mockShare.mockResolvedValue({ activityType: 'org.telegram.messenger' });
+
+      await shareFile({
+        blob: new Blob(['png'], { type: 'image/png' }),
+        fileName: 'contact-qr-code.png',
+        title: 'Gossip QR Code',
+      });
+
+      expect(mockWriteFile).toHaveBeenCalledWith({
+        path: 'contact-qr-code.png',
+        data: expect.any(String),
+        directory: Directory.Cache,
+      });
+      expect(mockShare).toHaveBeenCalledWith({
+        title: 'Gossip QR Code',
+        files: ['file:///cache/contact-qr-code.png'],
+        dialogTitle: 'Gossip QR Code',
+      });
+      expect(mockDeleteFile).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+
+      expect(mockDeleteFile).toHaveBeenCalledWith({
+        path: 'contact-qr-code.png',
+        directory: Directory.Cache,
+      });
+    });
+
+    it('uses a unique native cache filename for each share', async () => {
+      vi.useFakeTimers();
+      vi.stubGlobal(
+        'FileReader',
+        class {
+          result = 'data:image/png;base64,cG5n';
+          onloadend: (() => void) | null = null;
+          onerror: (() => void) | null = null;
+
+          readAsDataURL() {
+            this.onloadend?.();
+          }
+        }
+      );
+      mockShare.mockResolvedValue({ activityType: 'org.telegram.messenger' });
+      mockWriteFile.mockImplementation(async ({ path }) => ({
+        uri: `file:///cache/${path}`,
+      }));
+
+      await shareFile({
+        blob: new Blob(['png'], { type: 'image/png' }),
+        fileName: 'contact-qr-code.png',
+        title: 'Gossip QR Code',
+      });
+      await shareFile({
+        blob: new Blob(['png'], { type: 'image/png' }),
+        fileName: 'contact-qr-code.png',
+        title: 'Gossip QR Code',
+      });
+
+      const firstPath = mockWriteFile.mock.calls[0][0].path;
+      const secondPath = mockWriteFile.mock.calls[1][0].path;
+
+      expect(firstPath).toMatch(/^contact-qr-code-.+\.png$/);
+      expect(secondPath).toMatch(/^contact-qr-code-.+\.png$/);
+      expect(firstPath).not.toBe(secondPath);
+      expect(firstPath).not.toBe('contact-qr-code.png');
+      expect(secondPath).not.toBe('contact-qr-code.png');
+
+      await vi.runAllTimersAsync();
+
+      expect(mockDeleteFile).toHaveBeenCalledWith({
+        path: firstPath,
+        directory: Directory.Cache,
+      });
+      expect(mockDeleteFile).toHaveBeenCalledWith({
+        path: secondPath,
+        directory: Directory.Cache,
+      });
     });
   });
 });


### PR DESCRIPTION
sharing text works since #644 but sharing QR codes or other files fail on telegram.

This was due to the file getting instantly deleted, before the handover took place. I've added a unique filename and timeout to ensure the file wont be deleted for 60seconds after hitting "share". unique filenames prevent a previous share deleting another share's file