### PR TITLE
Fix #686 broken update

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -177,6 +177,9 @@ jobs:
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > ${{ github.workspace }}/android/app/keystore.jks
           echo "ANDROID_KEYSTORE_FILE=${{ github.workspace }}/android/app/keystore.jks" >> $GITHUB_ENV
 
+      - name: Pin shared Android versionCode
+        run: echo "ANDROID_VERSION_CODE=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Build Android Release (AAB)
         env:
           ANDROID_KEYSTORE_FILE: ${{ env.ANDROID_KEYSTORE_FILE }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -165,8 +165,12 @@ jobs:
       - name: Display build info
         run: |
           echo "📦 Building Android artifacts:"
-          echo "  • APK Debug (with sourcemaps)"
           echo "  • AAB Release (for Play Store)"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "  • APK Release (signed, for GitHub Release)"
+          else
+            echo "  • APK Debug (with sourcemaps)"
+          fi
 
       - name: Create keystore from secrets (Release only)
         run: |
@@ -184,7 +188,20 @@ jobs:
           echo "📦 Building signed Android App Bundle (Release)..."
           bundle exec fastlane build
 
+      - name: Build Android Release (APK)
+        if: github.event_name == 'release'
+        env:
+          ANDROID_KEYSTORE_FILE: ${{ env.ANDROID_KEYSTORE_FILE }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        working-directory: android
+        run: |
+          echo "📦 Building signed Android APK (Release)..."
+          ./gradlew assembleRelease
+
       - name: Build Android Debug (APK)
+        if: github.event_name != 'release'
         working-directory: android
         run: |
           echo "📦 Building Android APK (Debug with sourcemaps)..."
@@ -203,14 +220,21 @@ jobs:
             exit 1
           fi
 
-          # Check for Debug APK
-          if [ -f "android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-            echo "✅ Android APK (Debug) built successfully!"
-            echo "📦 File: android/app/build/outputs/apk/debug/app-debug.apk"
-            ls -lh android/app/build/outputs/apk/debug/app-debug.apk
-            echo "🔍 Sourcemaps included in web build"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            APK_PATH="android/app/build/outputs/apk/release/app-release.apk"
+            APK_KIND="Release"
           else
-            echo "❌ Expected Android APK (Debug) not found at android/app/build/outputs/apk/debug/app-debug.apk"
+            APK_PATH="android/app/build/outputs/apk/debug/app-debug.apk"
+            APK_KIND="Debug"
+          fi
+
+          # Check for APK
+          if [ -f "$APK_PATH" ]; then
+            echo "✅ Android APK ($APK_KIND) built successfully!"
+            echo "📦 File: $APK_PATH"
+            ls -lh "$APK_PATH"
+          else
+            echo "❌ Expected Android APK ($APK_KIND) not found at $APK_PATH"
             exit 1
           fi
 
@@ -225,10 +249,17 @@ jobs:
           echo "📦 Using version ${VERSION}${SUFFIX} for artifact names"
 
           # Copy APK with versioned name
-          if [ -f "android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-            cp android/app/build/outputs/apk/debug/app-debug.apk \
-               android/app/build/outputs/apk/debug/gossip-android-apk-${VERSION}${SUFFIX}.apk
-            echo "✅ Created android/app/build/outputs/apk/debug/gossip-android-apk-${VERSION}${SUFFIX}.apk"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            APK_DIR="android/app/build/outputs/apk/release"
+            APK_SOURCE="${APK_DIR}/app-release.apk"
+          else
+            APK_DIR="android/app/build/outputs/apk/debug"
+            APK_SOURCE="${APK_DIR}/app-debug.apk"
+          fi
+
+          if [ -f "$APK_SOURCE" ]; then
+            cp "$APK_SOURCE" "${APK_DIR}/gossip-android-apk-${VERSION}${SUFFIX}.apk"
+            echo "✅ Created ${APK_DIR}/gossip-android-apk-${VERSION}${SUFFIX}.apk"
           fi
 
           # Copy AAB with versioned name
@@ -247,12 +278,14 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-      - name: Upload APK artifact (Debug)
+      - name: Upload APK artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: gossip-android-apk
-          path: android/app/build/outputs/apk/debug/gossip-android-apk-*.apk
+          path: |
+            android/app/build/outputs/apk/release/gossip-android-apk-*.apk
+            android/app/build/outputs/apk/debug/gossip-android-apk-*.apk
           if-no-files-found: error
           retention-days: 14
 
@@ -363,7 +396,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gossip-android-apk
-          path: android/app/build/outputs/apk/debug/
+          path: android/app/build/outputs/apk/release/
 
       - name: Attach Android assets to GitHub Release
         if: github.event_name == 'release'
@@ -371,7 +404,7 @@ jobs:
         with:
           files: |
             android/app/build/outputs/bundle/release/gossip-android-aab-*.aab
-            android/app/build/outputs/apk/debug/gossip-android-apk-*.apk
+            android/app/build/outputs/apk/release/gossip-android-apk-*.apk
 
   build-ios:
     needs: build-web

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -396,7 +396,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gossip-android-apk
-          path: android/app/build/outputs/apk/release/
+          path: .release-assets/android-apk
 
       - name: Attach Android assets to GitHub Release
         if: github.event_name == 'release'
@@ -404,7 +404,7 @@ jobs:
         with:
           files: |
             android/app/build/outputs/bundle/release/gossip-android-aab-*.aab
-            android/app/build/outputs/apk/release/gossip-android-apk-*.apk
+            .release-assets/android-apk/**/*.apk
 
   build-ios:
     needs: build-web

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -252,14 +252,19 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             APK_DIR="android/app/build/outputs/apk/release"
             APK_SOURCE="${APK_DIR}/app-release.apk"
+            APK_KIND="Release"
           else
             APK_DIR="android/app/build/outputs/apk/debug"
             APK_SOURCE="${APK_DIR}/app-debug.apk"
+            APK_KIND="Debug"
           fi
 
           if [ -f "$APK_SOURCE" ]; then
             cp "$APK_SOURCE" "${APK_DIR}/gossip-android-apk-${VERSION}${SUFFIX}.apk"
             echo "✅ Created ${APK_DIR}/gossip-android-apk-${VERSION}${SUFFIX}.apk"
+          else
+            echo "❌ Expected Android APK ($APK_KIND) not found at $APK_SOURCE"
+            exit 1
           fi
 
           # Copy AAB with versioned name

--- a/ios/App/fastlane/Fastfile
+++ b/ios/App/fastlane/Fastfile
@@ -78,7 +78,8 @@ platform :ios do
       export_options: {
         method: "app-store",
         provisioningProfiles: {
-          "net.massa.gossip" => "match AppStore net.massa.gossip"
+          "net.massa.gossip" => "match AppStore net.massa.gossip",
+          "net.massa.gossip.GossipShareExtension" => "match AppStore net.massa.gossip.GossipShareExtension"
         },
         teamID: ENV["APPLE_TEAM_ID"]
       }
@@ -150,4 +151,3 @@ platform :ios do
     UI.error("❌ Error in lane '#{lane}': #{exception.message}")
   end
 end
-


### PR DESCRIPTION
This attemtps to fix #686 

The current releases were signed with throwaway keys (debug path) instead of the release keys.

This unfortunately means users of the 0.0.16 will experience data loss during the update.
It also means we **HAVE TO** implement import from mnemonic (removed for incompatibility with the new secure storage in #684) in version 0.0.17.

The process to update from 0.0.16 to 0.0.17+ will be:
1) backup data
for each session you have:
- unlock the session
- go to settings (click top left `⋮`, then `Settings`)  
- Click `Account Backup`
- Click `Show Backup`
- Save the mnemonic somewhere safe, preferably offline on a piece of paper.
2) uninstall the gossip app
3) re-install the gossip app
4) during on-boarding
- follow the on-boarding flow until the account creation page
- select `import from mnemonic`
- repeat for your other accounts.

IMPORTANT: importing accounts after the initial setup is not gonna be present in this version due to implications on PD for the secure storage, so you **NEED TO** import **ALL** your accounts during setup.

Following updates should hopefully update automatically and convert all your data seemlessly, this means your data should be preserved during updates after you migrated to 0.0.17 (but not before).