### PR TITLE
fix(sdk): make wasm loader compatible with node ESM

### DIFF
--- a/gossip-sdk/src/wasm/loader.ts
+++ b/gossip-sdk/src/wasm/loader.ts
@@ -9,7 +9,6 @@ import { logger } from '../utils/logs.js';
  */
 
 import { init } from './bindings.js';
-import gossipWasmUrl from '../assets/generated/wasm/gossip_wasm_bg.wasm?url';
 
 const WASM_PATH = '../assets/generated/wasm/gossip_wasm_bg.wasm';
 
@@ -67,6 +66,7 @@ export async function initializeWasm(): Promise<void> {
       } else {
         // Pre-fetch as ArrayBuffer so Safari doesn't choke on
         // chunked Transfer-Encoding during instantiateStreaming.
+        const gossipWasmUrl = new URL(WASM_PATH, import.meta.url).toString();
         const resp = await fetch(gossipWasmUrl);
         const wasmBytes = await resp.arrayBuffer();
         await init(wasmBytes);

--- a/gossip-sdk/src/wasm/loader.ts
+++ b/gossip-sdk/src/wasm/loader.ts
@@ -66,7 +66,10 @@ export async function initializeWasm(): Promise<void> {
       } else {
         // Pre-fetch as ArrayBuffer so Safari doesn't choke on
         // chunked Transfer-Encoding during instantiateStreaming.
-        const gossipWasmUrl = new URL(WASM_PATH, import.meta.url).toString();
+        const gossipWasmUrl = new URL(
+          '../assets/generated/wasm/gossip_wasm_bg.wasm',
+          import.meta.url
+        ).toString();
         const resp = await fetch(gossipWasmUrl);
         const wasmBytes = await resp.arrayBuffer();
         await init(wasmBytes);


### PR DESCRIPTION
This fixes some import issues with the current sdk.

Context: It was the only way I found to integrate my fork of https://github.com/Soulthym/hermes-agent, it requires this upstream change. I assume this would have affected other integrations.