### PR TITLE
fix(secure-storage): make init idempotent across WebView relaunches

### DIFF
--- a/gossip-sdk/src/gossip.ts
+++ b/gossip-sdk/src/gossip.ts
@@ -225,6 +225,8 @@ class GossipSdk {
   private _persistInFlightPromise: Promise<void> | null = null;
   /** Back-off state after a failed persist; reset on every success. */
   private _persistBackoffMs = 0;
+  /** Single-flight latch for `init()` — see `init` for the rationale. */
+  private _initPromise: Promise<GossipSdk> | null = null;
 
   // ─────────────────────────────────────────────────────────────────
   // Lifecycle
@@ -241,6 +243,39 @@ class GossipSdk {
       return this;
     }
 
+    // Single-flight latch. `this.state.status` only flips to INITIALIZED
+    // after the `await DatabaseConnection.create()` in `_doInit`, so two
+    // init() calls racing on the SAME instance would both pass the guard
+    // above and each open the DB — which native secure-storage rejects via
+    // redb's exclusive lock (DatabaseAlreadyOpen). Assigning the promise
+    // synchronously, before any await, closes that window; concurrent
+    // callers await the one init.
+    //
+    // Scope: this only dedupes concurrent inits on one instance. It does
+    // NOT cover a fresh WebView/Activity reusing a still-open
+    // process-global native handle (the notification-relaunch case) — a new
+    // instance has its own latch. That case is handled in the native
+    // layer's idempotent `init_native`.
+    if (this._initPromise) {
+      return this._initPromise;
+    }
+    const initPromise = this._doInit(options);
+    this._initPromise = initPromise;
+    try {
+      return await initPromise;
+    } catch (err) {
+      // A failed init must not poison retries — clear the latch. Guarded
+      // by identity: if a destroy() + fresh init() interleaved between
+      // the rejection and this catch, the latch now belongs to the newer
+      // init and must survive.
+      if (this._initPromise === initPromise) {
+        this._initPromise = null;
+      }
+      throw err;
+    }
+  }
+
+  private async _doInit(options: GossipSdkInitOptions): Promise<GossipSdk> {
     if (import.meta.env?.DEV) {
       logger.info('[GossipSdk] Initializing SDK');
     }
@@ -262,28 +297,50 @@ class GossipSdk {
     }
     this._conn = await DatabaseConnection.create({ storage: options.storage });
 
-    // Defer queries/profile when the database needs an unlock first.
-    if (this._conn.isOpen) {
-      this._queries = new Queries(this._conn);
+    try {
+      // Defer queries/profile when the database needs an unlock first.
+      if (this._conn.isOpen) {
+        this._queries = new Queries(this._conn);
+      }
+
+      if (import.meta.env?.DEV) {
+        logger.info('[GossipSdk] SQLite initialized');
+      }
+      // Create message protocol
+      const messageProtocol = createMessageProtocol();
+
+      // Create services that don't need a session
+      this._auth = new AuthService(createAuthProtocol());
+      this._profile = this._queries ? new ProfileService(this._queries) : null;
+
+      this.state = {
+        status: SdkStatus.INITIALIZED,
+        messageProtocol,
+        config,
+      };
+
+      return this;
+    } catch (err) {
+      // A failure after the DB opened must release the handle before the
+      // error propagates: `init()` clears its latch on failure, and the
+      // retry's `DatabaseConnection.create()` would otherwise hit the
+      // still-open handle — the same DatabaseAlreadyOpen boot error the
+      // single-flight latch exists to prevent. `_queries` is reset too:
+      // a retry on locked storage (`isOpen === false`) skips reassigning
+      // it and must not keep queries bound to the released connection.
+      const conn = this._conn;
+      this._conn = null;
+      this._queries = null;
+      if (conn) {
+        try {
+          await conn.close();
+        } catch {
+          // Best effort — the original init failure is the actionable
+          // error, not the close's.
+        }
+      }
+      throw err;
     }
-
-    if (import.meta.env?.DEV) {
-      logger.info('[GossipSdk] SQLite initialized');
-    }
-    // Create message protocol
-    const messageProtocol = createMessageProtocol();
-
-    // Create services that don't need a session
-    this._auth = new AuthService(createAuthProtocol());
-    this._profile = this._queries ? new ProfileService(this._queries) : null;
-
-    this.state = {
-      status: SdkStatus.INITIALIZED,
-      messageProtocol,
-      config,
-    };
-
-    return this;
   }
 
   /**
@@ -548,6 +605,7 @@ class GossipSdk {
       await this._conn.close();
       this._conn = null;
     }
+    this._initPromise = null;
     this.state = { status: SdkStatus.UNINITIALIZED };
   }
 

--- a/gossip-sdk/test/integration/sdk-lifecycle.spec.ts
+++ b/gossip-sdk/test/integration/sdk-lifecycle.spec.ts
@@ -8,6 +8,7 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { type EncryptionKey } from '../../src/wasm/encryption';
 import { GossipSdk } from '../../src/gossip';
+import { DatabaseConnection } from '../../src/db/sqlite';
 import { clearAllTables, getTestStorageConfig } from '../testDb';
 import { generateMnemonic } from '../../src/crypto/bip39';
 import { MockMessageProtocol } from '../mocks';
@@ -53,6 +54,7 @@ describe('GossipSdk lifecycle', () => {
     } catch {
       // may not be open
     }
+    vi.restoreAllMocks();
     resetLoggingForTests();
   });
 
@@ -63,6 +65,65 @@ describe('GossipSdk lifecycle', () => {
 
     await sdk.init({ storage: getTestStorageConfig() });
     expect(emittedWarnings.length).toBeGreaterThan(0);
+  });
+
+  it('dedupes concurrent init() calls into a single database open', async () => {
+    const createSpy = vi.spyOn(DatabaseConnection, 'create');
+
+    // Two callers race on the same instance: both must await the one
+    // in-flight init instead of each opening the DB — the native
+    // secure-storage backend rejects a second open (DatabaseAlreadyOpen).
+    const [a, b] = await Promise.all([
+      sdk.init({ storage: getTestStorageConfig() }),
+      sdk.init({ storage: getTestStorageConfig() }),
+    ]);
+
+    expect(a).toBe(sdk);
+    expect(b).toBe(sdk);
+    expect(sdk.isInitialized).toBe(true);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows retrying init() after a failed attempt', async () => {
+    vi.spyOn(DatabaseConnection, 'create').mockRejectedValueOnce(
+      new Error('transient storage failure')
+    );
+
+    await expect(sdk.init({ storage: getTestStorageConfig() })).rejects.toThrow(
+      'transient storage failure'
+    );
+    expect(sdk.isInitialized).toBe(false);
+
+    // The failed attempt must clear the single-flight latch so the retry
+    // runs a fresh init instead of being handed the rejected promise.
+    await sdk.init({ storage: getTestStorageConfig() });
+    expect(sdk.isInitialized).toBe(true);
+  });
+
+  it('releases the connection when init() fails after the database opened', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    // A connection whose first post-open step blows up: `_doInit` reads
+    // `isOpen` right after `create()` resolves.
+    const createSpy = vi
+      .spyOn(DatabaseConnection, 'create')
+      .mockResolvedValueOnce({
+        get isOpen(): boolean {
+          throw new Error('post-open failure');
+        },
+        close,
+      } as unknown as DatabaseConnection);
+
+    await expect(sdk.init({ storage: getTestStorageConfig() })).rejects.toThrow(
+      'post-open failure'
+    );
+
+    // The half-open handle must be released — otherwise the retry's
+    // create() hits DatabaseAlreadyOpen on native secure storage.
+    expect(close).toHaveBeenCalledTimes(1);
+
+    await sdk.init({ storage: getTestStorageConfig() });
+    expect(sdk.isInitialized).toBe(true);
+    expect(createSpy).toHaveBeenCalledTimes(2);
   });
 
   it('throws on openSession before init', async () => {

--- a/wasm/secure-storage/src/vfs/native_vfs.rs
+++ b/wasm/secure-storage/src/vfs/native_vfs.rs
@@ -56,6 +56,10 @@ const COVER_TRAFFIC_NAMESPACES: &[u8] = &[DEFAULT_NAMESPACE, SESSION_BLOB_NAMESP
 struct VfsState {
     backend: RedbStorage,
     domain: String,
+    /// Absolute path the redb handle was opened at. Stored so a second
+    /// `init_native` can verify it targets the same store before reusing
+    /// the process-global handle (see `init_native`).
+    path: String,
     session: Option<UnlockedSession>,
     namespace_states: HashMap<u8, NamespaceState>,
     /// Per-file read/write/sync state for the SQLite main DB.
@@ -137,12 +141,39 @@ fn io_methods() -> &'static sqlite3_io_methods {
 
 /// Create state with redb backend.
 pub fn init_native(path: &str, domain: &str) -> Result<()> {
-    let storage = RedbStorage::open(Path::new(path))?;
+    // Take the state lock FIRST so the "already initialised?" check and the
+    // open below are atomic. The native VFS owns ONE process-global redb
+    // handle, and redb takes an exclusive OS lock at `Database::create`.
+    // Two Capacitor bridges in the same process (the main UI and the
+    // foreground-sync runtime) can each call initSecureStorage; without
+    // this the second one reopens storage.redb and redb fails with
+    // `DatabaseAlreadyOpen` -> surfaced as the STORAGE error. Locking
+    // across the open also closes the TOCTOU where both bridges see `None`.
     let mutex = state_mutex();
     let mut guard = mutex.lock().map_err(|_| SecureStorageError::LockPoisoned)?;
+
+    if let Some(existing) = guard.as_ref() {
+        if existing.domain == domain && existing.path == path {
+            // Idempotent: the same (domain, path) store is already open —
+            // reuse the global handle.
+            return Ok(());
+        }
+        // A different domain OR path on an already-open DB is genuine
+        // misuse: the single global handle cannot serve two stores. Surface
+        // the mismatch rather than silently reusing the wrong one (or
+        // reopening, which would just hit the redb lock anyway).
+        return Err(SecureStorageError::Storage(format!(
+            "already initialised for (domain '{}', path '{}'), \
+             cannot re-init for (domain '{}', path '{}')",
+            existing.domain, existing.path, domain, path
+        )));
+    }
+
+    let storage = RedbStorage::open(Path::new(path))?;
     *guard = Some(VfsState {
         backend: storage,
         domain: domain.to_string(),
+        path: path.to_string(),
         session: None,
         namespace_states: HashMap::new(),
         main_file: EncryptedFileCore::new(),
@@ -574,6 +605,7 @@ fn flush_pending_writes(st: &mut VfsState) -> Result<()> {
     let VfsState {
         backend,
         domain,
+        path: _,
         session,
         namespace_states,
         main_file,
@@ -1063,6 +1095,7 @@ unsafe extern "C" fn x_truncate(file: *mut sqlite3_file, size: i64) -> c_int {
             let VfsState {
                 backend,
                 domain,
+                path: _,
                 session,
                 namespace_states,
                 main_file,
@@ -2070,6 +2103,73 @@ mod tests {
                 assert_eq!(val, "persisted");
                 drop(conn);
             }
+        });
+    }
+
+    #[test]
+    fn test_init_native_idempotent_reuses_open_store() {
+        run_with_stack(|| {
+            let _guard = test_mutex().lock().unwrap();
+            let (dir, conn) = setup_native_vfs();
+            let path = dir.path().to_str().unwrap().to_string();
+
+            conn.execute_batch(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT);
+                 INSERT INTO t VALUES (1, 'before-reinit');",
+            )
+            .unwrap();
+
+            // Second init for the same (path, domain) while the process-global
+            // handle is still open — the notification-relaunch case (a fresh
+            // WebView re-runs initSecureStorage in a surviving process). Must
+            // reuse the handle, not reopen (redb would fail with
+            // DatabaseAlreadyOpen).
+            init_native(&path, "test").unwrap();
+
+            // The reuse must not disturb live state: the session stays
+            // unlocked (a forced lock here would kill the UI bridge's session
+            // in the two-bridges case) and the open connection keeps working.
+            assert!(is_unlocked().unwrap());
+            let val: String = conn
+                .query_row("SELECT val FROM t WHERE id = 1", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(val, "before-reinit");
+            conn.execute("INSERT INTO t VALUES (2, 'after-reinit')", [])
+                .unwrap();
+
+            drop(conn);
+        });
+    }
+
+    #[test]
+    fn test_init_native_rejects_mismatched_store() {
+        run_with_stack(|| {
+            let _guard = test_mutex().lock().unwrap();
+            reset_state();
+            let dir_a = tempfile::tempdir().unwrap();
+            let dir_b = tempfile::tempdir().unwrap();
+            let path_a = dir_a.path().to_str().unwrap().to_string();
+            let path_b = dir_b.path().to_str().unwrap().to_string();
+
+            init_native(&path_a, "test").unwrap();
+
+            // The single global handle cannot serve two stores: a different
+            // path or domain is misuse and must surface, not silently swap
+            // the open store.
+            let err = init_native(&path_b, "test").expect_err("different path must be rejected");
+            assert!(
+                matches!(&err, SecureStorageError::Storage(msg) if msg.contains("already initialised")),
+                "expected mismatch error, got: {err}"
+            );
+            let err = init_native(&path_a, "other").expect_err("different domain must be rejected");
+            assert!(
+                matches!(&err, SecureStorageError::Storage(msg) if msg.contains("already initialised")),
+                "expected mismatch error, got: {err}"
+            );
+
+            // The failed calls must leave the original store untouched: the
+            // matching re-init still succeeds.
+            init_native(&path_a, "test").unwrap();
         });
     }
 }


### PR DESCRIPTION
## Problem

On Android the native process often outlives the WebView (notification relaunch, activity recreation — particularly aggressive on Samsung devices). The process-global redb handle stays open, so when the fresh WebView re-runs `initSecureStorage`, the Rust layer re-opened `storage.redb` while the previous handle was still alive. redb's exclusive lock rejects this with `DatabaseAlreadyOpen`, which surfaced as a STORAGE error at boot.

## Fix

Two complementary layers:

**Native (`native_vfs.rs`)** — `init_native` is now idempotent:
- The state lock is taken **before** the already-initialised check, so the check and the open are atomic. This also closes the TOCTOU where two Capacitor bridges in the same process (main UI + foreground-sync runtime) both see an empty state and race the open.
- A second init for the same `(path, domain)` reuses the open process-global handle instead of reopening. The existing session is deliberately left untouched: forcing a lock here would kill the UI bridge's live session in the two-bridges case.
- A mismatched `(path, domain)` on an already-open store is rejected with an explicit error instead of silently swapping stores.

**SDK (`gossip.ts`)** — single-flight latch in `init()`:
- Concurrent `init()` calls on one instance share a single `_doInit` instead of each opening the DB.
- A failed init releases the half-open connection (and detaches `_queries`) before clearing the latch, so a retry starts clean instead of hitting `DatabaseAlreadyOpen` against a leaked handle.

## Tests

- Rust (`cargo test --features native`): second `init_native` on the same store reuses the handle with the session kept unlocked and the live SQLite connection still working; mismatched path/domain is rejected and leaves the original store intact.
- TS (`sdk-lifecycle.spec.ts`): concurrent `init()` calls produce exactly one `DatabaseConnection.create`; a failed init can be retried; a failure after the DB opened closes the connection and the retry succeeds.
- Full runs green: native_vfs module 18/18, gossip-sdk suite 338/338.