### PR TITLE
feat: add multi-message forwarding

### DIFF
--- a/gossip-sdk/src/services/selfMessage.ts
+++ b/gossip-sdk/src/services/selfMessage.ts
@@ -90,9 +90,68 @@ export class SelfMessageService {
     return new TextDecoder().decode(plaintextBytes);
   }
 
-  async send(content: string): Promise<Message> {
+  private serializeForwardOf(forwardOf: Message['forwardOf']): string | null {
+    if (!forwardOf) return null;
+    return JSON.stringify({
+      originalContent: forwardOf.originalContent,
+      originalContactId: forwardOf.originalContactId
+        ? encodeToBase64(forwardOf.originalContactId)
+        : undefined,
+    });
+  }
+
+  private deserializeForwardOf(
+    json: string | null | undefined
+  ): Message['forwardOf'] {
+    if (!json) return undefined;
+    try {
+      const parsed = JSON.parse(json) as {
+        originalContent?: string;
+        originalContactId?: string;
+      };
+      return {
+        originalContent: parsed.originalContent,
+        originalContactId: parsed.originalContactId
+          ? decodeFromBase64(parsed.originalContactId)
+          : undefined,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Get a self-message by DB id with decrypted content. */
+  async get(id: number): Promise<Message | undefined> {
+    const row = await this.queries.messages.getById(id);
+    if (!row || row.contactUserId !== SELF_CONTACT_ID) return undefined;
+    try {
+      const plaintext = await this.decryptContent(row.content);
+      return {
+        id: row.id,
+        ownerUserId: row.ownerUserId,
+        contactUserId: row.contactUserId,
+        content: plaintext,
+        type: row.type,
+        direction: MessageDirection.OUTGOING,
+        status: row.status,
+        timestamp: row.timestamp,
+        forwardOf: this.deserializeForwardOf(row.forwardOf as string | null),
+        metadata: row.metadata
+          ? (JSON.parse(row.metadata as string) as Record<string, unknown>)
+          : undefined,
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  async send(
+    content: string,
+    options?: { forwardOf?: Message['forwardOf'] }
+  ): Promise<Message> {
     const encryptedContent = await this.encryptContent(content);
     const now = new Date();
+    const forwardOf = options?.forwardOf;
 
     const id = await this.queries.messages.insert({
       ownerUserId: this.ownerUserId,
@@ -102,6 +161,7 @@ export class SelfMessageService {
       direction: MessageDirection.OUTGOING,
       status: MessageStatus.SENT,
       timestamp: now,
+      forwardOf: this.serializeForwardOf(forwardOf),
     });
 
     const discussion = await this.queries.discussions.getByOwnerAndContact(
@@ -127,6 +187,7 @@ export class SelfMessageService {
       direction: MessageDirection.OUTGOING,
       status: MessageStatus.SENT,
       timestamp: now,
+      forwardOf,
     };
   }
 
@@ -150,6 +211,7 @@ export class SelfMessageService {
           direction: MessageDirection.OUTGOING,
           status: row.status,
           timestamp: row.timestamp,
+          forwardOf: this.deserializeForwardOf(row.forwardOf as string | null),
         });
       } catch {
         // Skip messages that cannot be decrypted

--- a/gossip-sdk/src/services/selfMessage.ts
+++ b/gossip-sdk/src/services/selfMessage.ts
@@ -120,6 +120,28 @@ export class SelfMessageService {
     }
   }
 
+  /** Encrypt forwardOf JSON for at-rest storage (same AEAD as content). */
+  private async encryptForwardOf(
+    forwardOf: Message['forwardOf']
+  ): Promise<string | null> {
+    const json = this.serializeForwardOf(forwardOf);
+    if (!json) return null;
+    return this.encryptContent(json);
+  }
+
+  /** Decrypt forwardOf from DB; null/empty stays undefined (legacy Notes rows). */
+  private async decryptForwardOf(
+    stored: string | null | undefined
+  ): Promise<Message['forwardOf']> {
+    if (!stored) return undefined;
+    try {
+      const json = await this.decryptContent(stored);
+      return this.deserializeForwardOf(json);
+    } catch {
+      return undefined;
+    }
+  }
+
   /** Get a self-message by DB id with decrypted content. */
   async get(id: number): Promise<Message | undefined> {
     const row = await this.queries.messages.getById(id);
@@ -135,7 +157,7 @@ export class SelfMessageService {
         direction: MessageDirection.OUTGOING,
         status: row.status,
         timestamp: row.timestamp,
-        forwardOf: this.deserializeForwardOf(row.forwardOf as string | null),
+        forwardOf: await this.decryptForwardOf(row.forwardOf as string | null),
         metadata: row.metadata
           ? (JSON.parse(row.metadata as string) as Record<string, unknown>)
           : undefined,
@@ -152,6 +174,7 @@ export class SelfMessageService {
     const encryptedContent = await this.encryptContent(content);
     const now = new Date();
     const forwardOf = options?.forwardOf;
+    const encryptedForwardOf = await this.encryptForwardOf(forwardOf);
 
     const id = await this.queries.messages.insert({
       ownerUserId: this.ownerUserId,
@@ -161,7 +184,7 @@ export class SelfMessageService {
       direction: MessageDirection.OUTGOING,
       status: MessageStatus.SENT,
       timestamp: now,
-      forwardOf: this.serializeForwardOf(forwardOf),
+      forwardOf: encryptedForwardOf,
     });
 
     const discussion = await this.queries.discussions.getByOwnerAndContact(
@@ -211,7 +234,9 @@ export class SelfMessageService {
           direction: MessageDirection.OUTGOING,
           status: row.status,
           timestamp: row.timestamp,
-          forwardOf: this.deserializeForwardOf(row.forwardOf as string | null),
+          forwardOf: await this.decryptForwardOf(
+            row.forwardOf as string | null
+          ),
         });
       } catch {
         // Skip messages that cannot be decrypted

--- a/gossip-sdk/src/utils/messageSerialization.ts
+++ b/gossip-sdk/src/utils/messageSerialization.ts
@@ -119,6 +119,9 @@ export function serializeForwardMessage(
   messageId: Uint8Array,
   originalContactId?: Uint8Array
 ): Uint8Array {
+  if (!forwardedContent) {
+    throw new Error('forwardedContent must not be empty');
+  }
   if (messageId.length !== MESSAGE_ID_SIZE) {
     throw new Error(`messageId must be ${MESSAGE_ID_SIZE} bytes`);
   }

--- a/gossip-sdk/test/services/selfMessage.spec.ts
+++ b/gossip-sdk/test/services/selfMessage.spec.ts
@@ -95,6 +95,68 @@ describe('SelfMessageService', () => {
     expect(msg.status).toBe(MessageStatus.SENT);
   });
 
+  it('encrypts forwardOf at rest and decrypts via get / getMessages', async () => {
+    const queries = getTestQueries();
+    const encKey = await generateEncryptionKey();
+    const ownerUserId = 'owner-self-forward';
+    const service = new SelfMessageService(queries, ownerUserId, encKey);
+
+    await service.ensureDiscussionExists();
+
+    const originalContactId = new Uint8Array(32).fill(9);
+    const forwardOf = {
+      originalContent: 'secret forwarded body',
+      originalContactId,
+    };
+    const result = await service.send('optional comment', { forwardOf });
+
+    expect(result.forwardOf).toEqual(forwardOf);
+    expect(result.content).toBe('optional comment');
+
+    const rows = await queries.messages.getByOwnerAndContact(
+      ownerUserId,
+      SELF_CONTACT_ID
+    );
+    expect(rows).toHaveLength(1);
+    const stored = rows[0];
+    expect(stored.forwardOf).toBeTruthy();
+    expect(stored.forwardOf).not.toContain('secret forwarded body');
+    expect(() => JSON.parse(stored.forwardOf as string)).toThrow();
+
+    const byId = await service.get(result.id!);
+    expect(byId?.forwardOf?.originalContent).toBe('secret forwarded body');
+    expect(byId?.forwardOf?.originalContactId).toEqual(originalContactId);
+
+    const listed = await service.getMessages();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].forwardOf?.originalContent).toBe('secret forwarded body');
+    expect(listed[0].forwardOf?.originalContactId).toEqual(originalContactId);
+  });
+
+  it('keeps Notes without forwardOf readable', async () => {
+    const queries = getTestQueries();
+    const encKey = await generateEncryptionKey();
+    const ownerUserId = 'owner-self-no-forward';
+    const service = new SelfMessageService(queries, ownerUserId, encKey);
+
+    await service.ensureDiscussionExists();
+    const result = await service.send('plain note');
+
+    const rows = await queries.messages.getByOwnerAndContact(
+      ownerUserId,
+      SELF_CONTACT_ID
+    );
+    expect(rows[0].forwardOf == null || rows[0].forwardOf === '').toBe(true);
+
+    const byId = await service.get(result.id!);
+    expect(byId?.content).toBe('plain note');
+    expect(byId?.forwardOf).toBeUndefined();
+
+    const listed = await service.getMessages();
+    expect(listed[0].content).toBe('plain note');
+    expect(listed[0].forwardOf).toBeUndefined();
+  });
+
   it('editMessage updates content and sets edited metadata', async () => {
     const queries = getTestQueries();
     const encKey = await generateEncryptionKey();

--- a/gossip-sdk/test/utils/serialization.spec.ts
+++ b/gossip-sdk/test/utils/serialization.spec.ts
@@ -97,6 +97,12 @@ describe('message serialization', () => {
       'Just forwarding this'
     );
   });
+
+  it('rejects a forward with no forwarded content', () => {
+    expect(() =>
+      serializeForwardMessage('', '', messageId, originalContactId)
+    ).toThrow('forwardedContent must not be empty');
+  });
 });
 
 describe('Deserialization Failure Handling', () => {

--- a/src/components/discussions/DiscussionTopSection.tsx
+++ b/src/components/discussions/DiscussionTopSection.tsx
@@ -11,6 +11,7 @@ interface DiscussionTopSectionSelectionProps {
   canDeleteSelected: boolean;
   onClearSelection: () => void;
   onCopySelected: () => void;
+  onForwardSelected: () => void;
   onDeleteSelected: () => void;
 }
 
@@ -55,6 +56,7 @@ const DiscussionTopSection: React.FC<DiscussionTopSectionProps> = ({
             count={selection.selectedCount}
             onClear={selection.onClearSelection}
             onCopy={selection.onCopySelected}
+            onForward={selection.onForwardSelected}
             onDelete={selection.onDeleteSelected}
             canDelete={selection.canDeleteSelected}
           />

--- a/src/components/discussions/MessageInput.tsx
+++ b/src/components/discussions/MessageInput.tsx
@@ -21,6 +21,7 @@ interface MessageInputProps {
   forwardPreview?: string | null;
   onCancelForward?: () => void;
   forwardMode?: 'forward' | 'reply';
+  forwardCount?: number;
   editingMessage?: Message | null;
   onCancelEdit?: () => void;
   onConfirmEdit?: (newContent: string, message: Message) => void;
@@ -39,6 +40,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
   forwardPreview,
   onCancelForward,
   forwardMode = 'forward',
+  forwardCount = 0,
   editingMessage,
   onCancelEdit,
   onConfirmEdit,
@@ -86,7 +88,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
     return () => clearTimeout(timer);
   }, [isKeyboardVisible, textareaRef]);
 
-  const isForwarding = !!forwardPreview;
+  const isForwarding = !!forwardPreview || forwardCount > 0;
   const sendButtonDisabled = disabled || (!newMessage.trim() && !isForwarding);
   const replyToId = replyingTo?.id;
 
@@ -178,11 +180,13 @@ const MessageInput: React.FC<MessageInputProps> = ({
         cancelAriaLabel={t('message_input.cancel_reply')}
       />
       <InputPreviewBanner
-        isVisible={!!forwardPreview}
+        isVisible={isForwarding}
         label={
-          forwardMode === 'reply'
-            ? t('message_input.replying_to')
-            : t('message_input.forwarding')
+          forwardCount > 1
+            ? t('message_input.forwarding_count', { count: forwardCount })
+            : forwardMode === 'reply'
+              ? t('message_input.replying_to')
+              : t('message_input.forwarding')
         }
         content={forwardPreview ?? ''}
         onCancel={onCancelForward}

--- a/src/components/discussions/SelectionHeader.tsx
+++ b/src/components/discussions/SelectionHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Copy, Trash2 } from 'react-feather';
+import { X, Copy, Trash2, Share } from 'react-feather';
 import HeaderBar from '../ui/HeaderBar';
 import Button from '../ui/Button';
 import AnimatedCounter from '../ui/AnimatedCounter';
@@ -9,6 +9,7 @@ interface SelectionHeaderProps {
   count: number;
   onClear: () => void;
   onCopy: () => void;
+  onForward: () => void;
   onDelete: () => void;
   canDelete?: boolean;
 }
@@ -17,6 +18,7 @@ const SelectionHeader: React.FC<SelectionHeaderProps> = ({
   count,
   onClear,
   onCopy,
+  onForward,
   onDelete,
   canDelete = true,
 }) => {
@@ -35,6 +37,15 @@ const SelectionHeader: React.FC<SelectionHeaderProps> = ({
         </Button>
         <AnimatedCounter value={count} />
         <div className="flex-1" />
+        <Button
+          onClick={onForward}
+          variant="circular"
+          size="custom"
+          ariaLabel={t('selection.forward_messages')}
+          className="w-8 h-8 flex items-center justify-center"
+        >
+          <Share className="w-5 h-5 text-muted-foreground" />
+        </Button>
         <Button
           onClick={onCopy}
           variant="circular"

--- a/src/hooks/useDiscussionActions.ts
+++ b/src/hooks/useDiscussionActions.ts
@@ -2,7 +2,7 @@ import { logger } from '../utils/logger.ts';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
-import { Message } from '@massalabs/gossip-sdk';
+import { Message, MessageType } from '@massalabs/gossip-sdk';
 import { ROUTES } from '../constants/routes';
 import { useAppStore } from '../stores/appStore';
 import { useMessageStore } from '../stores/messageStore';
@@ -12,18 +12,24 @@ interface UseDiscussionActionsParams {
   contact: { userId: string } | undefined;
   isSelecting: boolean;
   t: TFunction;
-  forwardFromMessageId: number | undefined;
+  forwardFromMessageIds: number[];
   setReplyingTo: (msg: Message | null) => void;
   setEditingMessage: (msg: Message | null) => void;
   setInputPrefill: (text: string | undefined) => void;
   clearForward: () => void;
 }
 
+function getForwardableMessages(messages: Message[]): Message[] {
+  return messages
+    .filter(m => m.id != null && m.id !== 0 && m.type !== MessageType.DELETED)
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+}
+
 export function useDiscussionActions({
   contact,
   isSelecting,
   t,
-  forwardFromMessageId,
+  forwardFromMessageIds,
   setReplyingTo,
   setEditingMessage,
   setInputPrefill,
@@ -34,25 +40,34 @@ export function useDiscussionActions({
   const deleteMessage = useMessageStore(s => s.deleteMessage);
   const editMessage = useMessageStore(s => s.editMessage);
   const setPendingSharedContent = useAppStore(s => s.setPendingSharedContent);
-  const setPendingForwardMessageId = useAppStore(
-    s => s.setPendingForwardMessageId
+  const setPendingForwardMessageIds = useAppStore(
+    s => s.setPendingForwardMessageIds
   );
 
   const handleSendMessage = useCallback(
     async (text: string, replyToId?: number) => {
       if (isSelecting) return;
       if (!contact?.userId) return;
+      const idsToForward = [...forwardFromMessageIds];
       setReplyingTo(null);
       setEditingMessage(null);
       clearForward();
       setInputPrefill(undefined);
       try {
-        await sendMessage(
-          contact.userId,
-          text,
-          replyToId,
-          forwardFromMessageId
-        );
+        if (idsToForward.length === 0) {
+          await sendMessage(contact.userId, text, replyToId);
+          return;
+        }
+        // Send each selected message as its own forward (timestamp order).
+        // Optional composer text attaches to the first forward only.
+        for (let i = 0; i < idsToForward.length; i++) {
+          await sendMessage(
+            contact.userId,
+            i === 0 ? text : '',
+            i === 0 ? replyToId : undefined,
+            idsToForward[i]
+          );
+        }
       } catch (error) {
         toast.error(t('failed_to_send'));
         logger.error('Failed to send message:', error);
@@ -62,7 +77,7 @@ export function useDiscussionActions({
       isSelecting,
       sendMessage,
       contact?.userId,
-      forwardFromMessageId,
+      forwardFromMessageIds,
       t,
       clearForward,
       setReplyingTo,
@@ -81,17 +96,25 @@ export function useDiscussionActions({
     [setReplyingTo, setEditingMessage, clearForward]
   );
 
-  const handleForwardMessage = useCallback(
-    (message: Message) => {
-      if (!message.id) return;
+  const handleForwardMessages = useCallback(
+    (messages: Message[]) => {
+      const eligible = getForwardableMessages(messages);
+      if (eligible.length === 0) return;
       // Set pending forward state, then go to discussions list for recipient selection.
       // replace: true avoids pushing a duplicate /discussions entry so back navigation
       // after forwarding returns cleanly to the discussions list.
-      setPendingSharedContent(message.content);
-      setPendingForwardMessageId(message.id);
+      setPendingSharedContent(eligible[0].content);
+      setPendingForwardMessageIds(eligible.map(m => m.id!));
       navigate(ROUTES.discussions(), { replace: true });
     },
-    [navigate, setPendingForwardMessageId, setPendingSharedContent]
+    [navigate, setPendingForwardMessageIds, setPendingSharedContent]
+  );
+
+  const handleForwardMessage = useCallback(
+    (message: Message) => {
+      handleForwardMessages([message]);
+    },
+    [handleForwardMessages]
   );
 
   const handleEditMessage = useCallback(
@@ -150,6 +173,7 @@ export function useDiscussionActions({
     handleSendMessage,
     handleReplyToMessage,
     handleForwardMessage,
+    handleForwardMessages,
     handleEditMessage,
     handleDeleteMessage,
     handleCancelReply,

--- a/src/hooks/useForwardPreview.ts
+++ b/src/hooks/useForwardPreview.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { GossipSdk } from '@massalabs/gossip-sdk';
+import { getForwardSourceContent } from '../utils/messages';
 
 interface UseForwardPreviewParams {
   gossip: GossipSdk;
@@ -15,13 +16,10 @@ async function loadForwardSourceContent(
   // parse of encrypted Notes forwardOf.
   const selfMsg = await gossip.selfMessages.get(messageId);
   if (selfMsg) {
-    const nested = selfMsg.forwardOf?.originalContent;
-    return typeof nested === 'string' && nested.length > 0
-      ? nested
-      : selfMsg.content;
+    return getForwardSourceContent(selfMsg) || null;
   }
   const row = await gossip.messages.get(messageId);
-  return row?.content ?? null;
+  return row ? getForwardSourceContent(row) || null : null;
 }
 
 export function useForwardPreview({

--- a/src/hooks/useForwardPreview.ts
+++ b/src/hooks/useForwardPreview.ts
@@ -1,49 +1,55 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { GossipSdk, Contact } from '@massalabs/gossip-sdk';
+import type { GossipSdk } from '@massalabs/gossip-sdk';
+import { SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
 
 interface UseForwardPreviewParams {
   gossip: GossipSdk;
-  contact: Contact | undefined;
-  initialForwardFromMessageId: number | undefined;
+  initialForwardFromMessageIds: number[] | undefined;
   setReplyingTo: (msg: import('@massalabs/gossip-sdk').Message | null) => void;
+}
+
+async function loadForwardSourceContent(
+  gossip: GossipSdk,
+  messageId: number
+): Promise<string | null> {
+  const row = await gossip.messages.get(messageId);
+  if (!row) return null;
+  if (row.contactUserId === SELF_CONTACT_ID) {
+    const decrypted = await gossip.selfMessages.get(messageId);
+    return decrypted?.content ?? null;
+  }
+  return row.content;
 }
 
 export function useForwardPreview({
   gossip,
-  contact,
-  initialForwardFromMessageId,
+  initialForwardFromMessageIds,
   setReplyingTo,
 }: UseForwardPreviewParams) {
   const [forwardPreviewText, setForwardPreviewText] = useState<string | null>(
     null
   );
-  const [forwardPreviewMode, setForwardPreviewMode] = useState<
-    'forward' | 'reply'
-  >('forward');
-  const [forwardFromMessageId, setForwardFromMessageId] = useState<
-    number | undefined
-  >(initialForwardFromMessageId);
+  const [forwardFromMessageIds, setForwardFromMessageIds] = useState<number[]>(
+    initialForwardFromMessageIds ?? []
+  );
 
   useEffect(() => {
     let cancelled = false;
 
     const loadForwardPreview = async () => {
-      if (forwardFromMessageId == null) {
+      if (forwardFromMessageIds.length === 0) {
         setForwardPreviewText(null);
-        setForwardPreviewMode('forward');
         return;
       }
 
       // Reply and forward are mutually exclusive
       setReplyingTo(null);
-      const original = await gossip.messages.get(forwardFromMessageId);
+      const content = await loadForwardSourceContent(
+        gossip,
+        forwardFromMessageIds[0]
+      );
       if (!cancelled) {
-        setForwardPreviewText(original?.content ?? null);
-        if (original && contact && original.contactUserId === contact.userId) {
-          setForwardPreviewMode('reply');
-        } else {
-          setForwardPreviewMode('forward');
-        }
+        setForwardPreviewText(content);
       }
     };
 
@@ -52,18 +58,18 @@ export function useForwardPreview({
     return () => {
       cancelled = true;
     };
-  }, [forwardFromMessageId, contact, gossip, setReplyingTo]);
+  }, [forwardFromMessageIds, gossip, setReplyingTo]);
 
   const clearForward = useCallback(() => {
-    setForwardFromMessageId(undefined);
+    setForwardFromMessageIds([]);
     setForwardPreviewText(null);
   }, []);
 
   return {
-    forwardFromMessageId,
-    setForwardFromMessageId,
+    forwardFromMessageIds,
+    setForwardFromMessageIds,
     forwardPreviewText,
-    forwardPreviewMode,
+    forwardPreviewMode: 'forward' as const,
     clearForward,
   };
 }

--- a/src/hooks/useForwardPreview.ts
+++ b/src/hooks/useForwardPreview.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { GossipSdk } from '@massalabs/gossip-sdk';
-import { SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
 
 interface UseForwardPreviewParams {
   gossip: GossipSdk;
@@ -12,13 +11,17 @@ async function loadForwardSourceContent(
   gossip: GossipSdk,
   messageId: number
 ): Promise<string | null> {
-  const row = await gossip.messages.get(messageId);
-  if (!row) return null;
-  if (row.contactUserId === SELF_CONTACT_ID) {
-    const decrypted = await gossip.selfMessages.get(messageId);
-    return decrypted?.content ?? null;
+  // Notes first (SelfMessageService); avoids MessageService plaintext JSON
+  // parse of encrypted Notes forwardOf.
+  const selfMsg = await gossip.selfMessages.get(messageId);
+  if (selfMsg) {
+    const nested = selfMsg.forwardOf?.originalContent;
+    return typeof nested === 'string' && nested.length > 0
+      ? nested
+      : selfMsg.content;
   }
-  return row.content;
+  const row = await gossip.messages.get(messageId);
+  return row?.content ?? null;
 }
 
 export function useForwardPreview({

--- a/src/i18n/locales/en/discussions.json
+++ b/src/i18n/locales/en/discussions.json
@@ -13,6 +13,7 @@
   "message_input": {
     "replying_to": "Replying to",
     "forwarding": "Forwarding message",
+    "forwarding_count": "Forwarding {{count}} messages",
     "editing": "Editing message",
     "placeholder": "Type a message",
     "cancel_reply": "Cancel reply",
@@ -47,6 +48,7 @@
   },
   "selection": {
     "clear": "Clear selection",
+    "forward_messages": "Forward selected messages",
     "copy_messages": "Copy selected messages",
     "delete_messages": "Delete selected messages"
   },

--- a/src/i18n/locales/fr/discussions.json
+++ b/src/i18n/locales/fr/discussions.json
@@ -13,6 +13,7 @@
   "message_input": {
     "replying_to": "En réponse à",
     "forwarding": "Transfert du message",
+    "forwarding_count": "Transfert de {{count}} messages",
     "editing": "Modification du message",
     "placeholder": "Écrire un message",
     "cancel_reply": "Annuler la réponse",
@@ -47,6 +48,7 @@
   },
   "selection": {
     "clear": "Effacer la sélection",
+    "forward_messages": "Transférer les messages sélectionnés",
     "copy_messages": "Copier les messages sélectionnés",
     "delete_messages": "Supprimer les messages sélectionnés"
   },

--- a/src/i18n/locales/ru/discussions.json
+++ b/src/i18n/locales/ru/discussions.json
@@ -13,6 +13,7 @@
   "message_input": {
     "replying_to": "Ответ для",
     "forwarding": "Пересылка сообщения",
+    "forwarding_count": "Пересылка {{count}} сообщений",
     "editing": "Редактирование сообщения",
     "placeholder": "Введите сообщение",
     "cancel_reply": "Отменить ответ",
@@ -47,6 +48,7 @@
   },
   "selection": {
     "clear": "Очистить выбор",
+    "forward_messages": "Переслать выбранные сообщения",
     "copy_messages": "Копировать выбранные сообщения",
     "delete_messages": "Удалить выбранные сообщения"
   },

--- a/src/i18n/locales/zh-CN/discussions.json
+++ b/src/i18n/locales/zh-CN/discussions.json
@@ -13,6 +13,7 @@
   "message_input": {
     "replying_to": "回复",
     "forwarding": "转发消息",
+    "forwarding_count": "转发 {{count}} 条消息",
     "editing": "编辑消息",
     "placeholder": "输入消息",
     "cancel_reply": "取消回复",
@@ -47,6 +48,7 @@
   },
   "selection": {
     "clear": "清除选择",
+    "forward_messages": "转发所选消息",
     "copy_messages": "复制所选消息",
     "delete_messages": "删除所选消息"
   },

--- a/src/pages/Discussion.tsx
+++ b/src/pages/Discussion.tsx
@@ -50,10 +50,11 @@ const Discussion: React.FC = () => {
 
   const locationState = location.state as {
     prefilledMessage?: string;
-    forwardFromMessageId?: number;
+    forwardFromMessageIds?: number[];
     scrollToMessageId?: number;
   } | null;
   const prefilledMessage = locationState?.prefilledMessage;
+  const initialForwardFromMessageIds = locationState?.forwardFromMessageIds;
 
   const pendingSharedContent = useAppStore(s => s.pendingSharedContent);
   const setPendingSharedContent = useAppStore(s => s.setPendingSharedContent);
@@ -94,16 +95,16 @@ const Discussion: React.FC = () => {
   });
 
   const {
-    forwardFromMessageId,
+    forwardFromMessageIds,
     forwardPreviewText,
     forwardPreviewMode,
     clearForward,
   } = useForwardPreview({
     gossip,
-    contact: contact ?? undefined,
-    initialForwardFromMessageId: locationState?.forwardFromMessageId,
+    initialForwardFromMessageIds,
     setReplyingTo,
   });
+  const isForwarding = forwardFromMessageIds.length > 0;
 
   const showDebugOption = useAppStore(s => s.showDebugOption);
   const defaultRetentionDuration = useAppStore(s => s.defaultRetentionDuration);
@@ -131,6 +132,7 @@ const Discussion: React.FC = () => {
   const {
     selectedMessageIds,
     isSelecting,
+    selectedMessages,
     canDeleteSelected,
     outgoingSentCount,
     handleToggleSelect,
@@ -147,6 +149,7 @@ const Discussion: React.FC = () => {
     handleSendMessage,
     handleReplyToMessage,
     handleForwardMessage,
+    handleForwardMessages,
     handleEditMessage,
     handleDeleteMessage,
     handleCancelReply,
@@ -157,12 +160,17 @@ const Discussion: React.FC = () => {
     contact: contact ?? undefined,
     isSelecting,
     t,
-    forwardFromMessageId,
+    forwardFromMessageIds,
     setReplyingTo,
     setEditingMessage,
     setInputPrefill,
     clearForward,
   });
+
+  const handleForwardSelected = useCallback(() => {
+    handleForwardMessages(selectedMessages);
+    handleClearSelection();
+  }, [handleForwardMessages, selectedMessages, handleClearSelection]);
 
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -341,6 +349,7 @@ const Discussion: React.FC = () => {
             canDeleteSelected,
             onClearSelection: handleClearSelection,
             onCopySelected: handleCopySelected,
+            onForwardSelected: handleForwardSelected,
             onDeleteSelected: handleDeleteSelected,
           }}
           search={{
@@ -369,9 +378,10 @@ const Discussion: React.FC = () => {
           onSend={handleSendMessage}
           replyingTo={replyingTo}
           onCancelReply={handleCancelReply}
-          initialValue={forwardFromMessageId ? undefined : inputPrefill}
-          forwardPreview={forwardFromMessageId ? forwardPreviewText : null}
+          initialValue={isForwarding ? undefined : inputPrefill}
+          forwardPreview={isForwarding ? forwardPreviewText : null}
           forwardMode={forwardPreviewMode}
+          forwardCount={forwardFromMessageIds.length}
           onCancelForward={clearForward}
           onFocus={handleInputFocus}
           editingMessage={editingMessage}

--- a/src/pages/Discussions.tsx
+++ b/src/pages/Discussions.tsx
@@ -30,7 +30,10 @@ import { useSwipeFilter } from '../hooks/useSwipeFilter';
 import { useUiStore } from '../stores/uiStore';
 import { prewarmShareQR } from '../components/settings/shareContactQrCache';
 import { generateDeepLinkUrl } from '../utils/invite';
-import { resolveDiscussionSelectDestination } from '../utils/discussionSelectDestination';
+import {
+  hasPendingDiscussionSelection,
+  resolveDiscussionSelectDestination,
+} from '../utils/discussionSelectDestination';
 
 const Discussions: React.FC = () => {
   const { t } = useTranslation('discussions');
@@ -53,6 +56,10 @@ const Discussions: React.FC = () => {
   const pendingForwardMessageIds = useAppStore(s => s.pendingForwardMessageIds);
   const setPendingForwardMessageIds = useAppStore(
     s => s.setPendingForwardMessageIds
+  );
+  const hasPendingDestinationSelection = hasPendingDiscussionSelection(
+    pendingForwardMessageIds,
+    pendingSharedContent
   );
   const discussions = useDiscussionStore(s => s.discussions);
   const filter = useDiscussionStore(s => s.filter);
@@ -235,8 +242,8 @@ const Discussions: React.FC = () => {
       contentClassName="px-2 pb-4 flex flex-col"
       onScrollContainerRef={setScrollContainer}
     >
-      {/* Show banner when there's pending shared content */}
-      {pendingSharedContent && (
+      {/* Show banner while selecting a share/forward destination. */}
+      {hasPendingDestinationSelection && (
         <div className="mx-2 mb-4 p-4 bg-accent/50 border border-border rounded-lg">
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0">

--- a/src/pages/Discussions.tsx
+++ b/src/pages/Discussions.tsx
@@ -49,9 +49,9 @@ const Discussions: React.FC = () => {
   }, [userId, username]);
   const pendingSharedContent = useAppStore(s => s.pendingSharedContent);
   const setPendingSharedContent = useAppStore(s => s.setPendingSharedContent);
-  const pendingForwardMessageId = useAppStore(s => s.pendingForwardMessageId);
-  const setPendingForwardMessageId = useAppStore(
-    s => s.setPendingForwardMessageId
+  const pendingForwardMessageIds = useAppStore(s => s.pendingForwardMessageIds);
+  const setPendingForwardMessageIds = useAppStore(
+    s => s.setPendingForwardMessageIds
   );
   const discussions = useDiscussionStore(s => s.discussions);
   const filter = useDiscussionStore(s => s.filter);
@@ -79,13 +79,13 @@ const Discussions: React.FC = () => {
       }, 600);
 
       if (contactUserId === SELF_CONTACT_ID) {
-        if (pendingForwardMessageId != null) {
+        if (pendingForwardMessageIds.length > 0) {
           navigate(ROUTES.selfDiscussion(), {
-            state: { forwardFromMessageId: pendingForwardMessageId },
+            state: { forwardFromMessageIds: pendingForwardMessageIds },
             replace: false,
           });
           setPendingSharedContent(null);
-          setPendingForwardMessageId(null);
+          setPendingForwardMessageIds([]);
         } else {
           navigate(ROUTES.selfDiscussion());
         }
@@ -93,8 +93,8 @@ const Discussions: React.FC = () => {
       }
       if (pendingSharedContent) {
         const state =
-          pendingForwardMessageId != null
-            ? { forwardFromMessageId: pendingForwardMessageId }
+          pendingForwardMessageIds.length > 0
+            ? { forwardFromMessageIds: pendingForwardMessageIds }
             : { prefilledMessage: pendingSharedContent };
 
         navigate(ROUTES.discussion({ userId: contactUserId }), {
@@ -102,7 +102,7 @@ const Discussions: React.FC = () => {
           replace: false,
         });
         setPendingSharedContent(null);
-        setPendingForwardMessageId(null);
+        setPendingForwardMessageIds([]);
       } else {
         navigate(ROUTES.discussion({ userId: contactUserId }));
       }
@@ -110,16 +110,16 @@ const Discussions: React.FC = () => {
     [
       navigate,
       pendingSharedContent,
-      pendingForwardMessageId,
+      pendingForwardMessageIds,
       setPendingSharedContent,
-      setPendingForwardMessageId,
+      setPendingForwardMessageIds,
     ]
   );
 
   const handleCancelShare = useCallback(() => {
     setPendingSharedContent(null);
-    setPendingForwardMessageId(null);
-  }, [setPendingSharedContent, setPendingForwardMessageId]);
+    setPendingForwardMessageIds([]);
+  }, [setPendingSharedContent, setPendingForwardMessageIds]);
 
   const {
     query: searchQuery,

--- a/src/pages/Discussions.tsx
+++ b/src/pages/Discussions.tsx
@@ -24,12 +24,13 @@ import ThreeDotMenu, { MenuItem } from '../components/ui/ThreeDotMenu';
 import { ROUTES } from '../constants/routes';
 import { useDiscussionStore } from '../stores/discussionStore';
 import { useGossipSdk } from '../hooks/useGossipSdk';
-import { SessionStatus, SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
+import { SessionStatus } from '@massalabs/gossip-sdk';
 import { useOnlineStore } from '../stores/useOnlineStore';
 import { useSwipeFilter } from '../hooks/useSwipeFilter';
 import { useUiStore } from '../stores/uiStore';
 import { prewarmShareQR } from '../components/settings/shareContactQrCache';
 import { generateDeepLinkUrl } from '../utils/invite';
+import { resolveDiscussionSelectDestination } from '../utils/discussionSelectDestination';
 
 const Discussions: React.FC = () => {
   const { t } = useTranslation('discussions');
@@ -78,33 +79,24 @@ const Discussions: React.FC = () => {
         isNavigatingRef.current = false;
       }, 600);
 
-      if (contactUserId === SELF_CONTACT_ID) {
-        if (pendingForwardMessageIds.length > 0) {
-          navigate(ROUTES.selfDiscussion(), {
-            state: { forwardFromMessageIds: pendingForwardMessageIds },
-            replace: false,
-          });
-          setPendingSharedContent(null);
-          setPendingForwardMessageIds([]);
-        } else {
-          navigate(ROUTES.selfDiscussion());
-        }
-        return;
-      }
-      if (pendingSharedContent) {
-        const state =
-          pendingForwardMessageIds.length > 0
-            ? { forwardFromMessageIds: pendingForwardMessageIds }
-            : { prefilledMessage: pendingSharedContent };
-
-        navigate(ROUTES.discussion({ userId: contactUserId }), {
-          state,
+      const destination = resolveDiscussionSelectDestination(
+        contactUserId,
+        pendingForwardMessageIds,
+        pendingSharedContent
+      );
+      if (destination.state) {
+        navigate(destination.path, {
+          state: destination.state,
           replace: false,
         });
-        setPendingSharedContent(null);
-        setPendingForwardMessageIds([]);
       } else {
-        navigate(ROUTES.discussion({ userId: contactUserId }));
+        navigate(destination.path);
+      }
+      if (destination.clearPendingSharedContent) {
+        setPendingSharedContent(null);
+      }
+      if (destination.clearPendingForwardIds) {
+        setPendingForwardMessageIds([]);
       }
     },
     [

--- a/src/pages/SelfDiscussion.tsx
+++ b/src/pages/SelfDiscussion.tsx
@@ -9,7 +9,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Clock, Settings } from 'react-feather';
-import { MessageDirection, Message } from '@massalabs/gossip-sdk';
+import { MessageDirection, Message, MessageType } from '@massalabs/gossip-sdk';
 import BackButton from '../components/ui/BackButton';
 import MessageList, {
   MessageListHandle,
@@ -17,20 +17,17 @@ import MessageList, {
 import MessageInput from '../components/discussions/MessageInput';
 import DiscussionLayout from '../components/ui/Layout/DiscussionLayout';
 import { useSelfMessageStore } from '../stores/selfMessageStore';
-import { getSdk } from '../stores/sdkStore';
+import { useAppStore } from '../stores/appStore';
 import { ROUTES } from '../constants/routes';
 import { useDiscussionMessageSelection } from '../hooks/useDiscussionMessageSelection';
 import { useGossipSdk } from '../hooks/useGossipSdk';
+import { useForwardPreview } from '../hooks/useForwardPreview';
 import SelectionHeader from '../components/discussions/SelectionHeader';
 import { useRetentionPolicy } from '../hooks/useRetentionPolicy';
 import { useKeyboardStore } from '../stores/keyboardStore';
 import { useHeaderScrollDetection } from '../hooks/useHeaderScrollDetection';
 import { ExitAnimationContext } from '../components/ui/ExitAnimationContext';
 import { useUiStore } from '../stores/uiStore';
-
-// Module-level guard so a given forward id is processed once across remounts
-// (StrictMode, route animation, back/forward nav).
-const handledForwardIds = new Set<number>();
 
 const RETENTION_OPTIONS: {
   labelKey: string;
@@ -114,31 +111,65 @@ const SelfDiscussion: React.FC = () => {
     retentionInfo,
   } = useRetentionPolicy(t);
 
-  const forwardFromMessageId = (
-    location.state as { forwardFromMessageId?: number } | undefined
-  )?.forwardFromMessageId;
+  const locationState = location.state as {
+    forwardFromMessageIds?: number[];
+  } | null;
+  const initialForwardFromMessageIds = locationState?.forwardFromMessageIds;
 
-  // Prefill the MessageInput with the forwarded content instead of sending
-  // immediately — user reviews/edits and hits send to confirm.
-  const [forwardDraft, setForwardDraft] = useState<string | undefined>(
-    undefined
+  const {
+    forwardFromMessageIds,
+    forwardPreviewText,
+    forwardPreviewMode,
+    clearForward,
+  } = useForwardPreview({
+    gossip,
+    initialForwardFromMessageIds,
+    setReplyingTo,
+  });
+  const isForwarding = forwardFromMessageIds.length > 0;
+
+  const setPendingSharedContent = useAppStore(s => s.setPendingSharedContent);
+  const setPendingForwardMessageIds = useAppStore(
+    s => s.setPendingForwardMessageIds
   );
 
-  useEffect(() => {
-    if (forwardFromMessageId == null) return;
-    if (handledForwardIds.has(forwardFromMessageId)) return;
-    handledForwardIds.add(forwardFromMessageId);
+  const handleForwardMessages = useCallback(
+    (msgs: Message[]) => {
+      const eligible = msgs
+        .filter(
+          m => m.id != null && m.id !== 0 && m.type !== MessageType.DELETED
+        )
+        .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      if (eligible.length === 0) return;
+      setPendingSharedContent(eligible[0].content);
+      setPendingForwardMessageIds(eligible.map(m => m.id!));
+      navigate(ROUTES.discussions(), { replace: true });
+    },
+    [navigate, setPendingForwardMessageIds, setPendingSharedContent]
+  );
 
-    const idToForward = forwardFromMessageId;
-    navigate(ROUTES.selfDiscussion(), { replace: true, state: {} });
+  const handleForwardMessage = useCallback(
+    (message: Message) => {
+      handleForwardMessages([message]);
+    },
+    [handleForwardMessages]
+  );
 
-    void (async () => {
-      const msg = await getSdk().messages.get(idToForward);
-      if (msg?.content) {
-        setForwardDraft(msg.content);
+  const handleSend = useCallback(
+    async (content: string) => {
+      const idsToForward = [...forwardFromMessageIds];
+      setReplyingTo(null);
+      clearForward();
+      if (idsToForward.length === 0) {
+        await sendMessage(content);
+        return;
       }
-    })();
-  }, [forwardFromMessageId, navigate]);
+      for (let i = 0; i < idsToForward.length; i++) {
+        await sendMessage(i === 0 ? content : '', idsToForward[i]);
+      }
+    },
+    [forwardFromMessageIds, sendMessage, clearForward]
+  );
 
   useEffect(() => {
     void loadMessages();
@@ -156,6 +187,7 @@ const SelfDiscussion: React.FC = () => {
 
   const {
     selectedMessageIds,
+    selectedMessages,
     isSelecting,
     handleToggleSelect,
     handleClearSelection,
@@ -172,11 +204,17 @@ const SelfDiscussion: React.FC = () => {
     },
   });
 
+  const handleForwardSelected = useCallback(() => {
+    handleForwardMessages(selectedMessages);
+    handleClearSelection();
+  }, [handleForwardMessages, selectedMessages, handleClearSelection]);
+
   const header = isSelecting ? (
     <SelectionHeader
       count={selectedMessageIds.size}
       onClear={handleClearSelection}
       onCopy={handleCopySelected}
+      onForward={handleForwardSelected}
       onDelete={handleDeleteSelected}
       canDelete={canDeleteSelected}
     />
@@ -259,11 +297,13 @@ const SelfDiscussion: React.FC = () => {
         <MessageInput
           disabled={isSelecting}
           isSelecting={isSelecting}
-          initialValue={editingMessage?.content ?? forwardDraft}
+          initialValue={editingMessage?.content ?? undefined}
+          forwardPreview={isForwarding ? forwardPreviewText : null}
+          forwardMode={forwardPreviewMode}
+          forwardCount={forwardFromMessageIds.length}
+          onCancelForward={clearForward}
           onSend={content => {
-            void sendMessage(content);
-            setReplyingTo(null);
-            setForwardDraft(undefined);
+            void handleSend(content);
           }}
           replyingTo={replyingTo}
           onCancelReply={() => setReplyingTo(null)}
@@ -305,12 +345,14 @@ const SelfDiscussion: React.FC = () => {
             onEdit={message => {
               setEditingMessage(message);
               setReplyingTo(null);
+              clearForward();
             }}
             onDelete={message => {
               if (message.id != null) {
                 void deleteMessage(message.id);
               }
             }}
+            onForward={handleForwardMessage}
             getReactions={getReactions}
             onReact={(message, emoji) => {
               if (message.id != null) {

--- a/src/pages/SelfDiscussion.tsx
+++ b/src/pages/SelfDiscussion.tsx
@@ -28,6 +28,8 @@ import { useKeyboardStore } from '../stores/keyboardStore';
 import { useHeaderScrollDetection } from '../hooks/useHeaderScrollDetection';
 import { ExitAnimationContext } from '../components/ui/ExitAnimationContext';
 import { useUiStore } from '../stores/uiStore';
+import toast from 'react-hot-toast';
+import { logger } from '../utils/logger';
 
 const RETENTION_OPTIONS: {
   labelKey: string;
@@ -164,11 +166,16 @@ const SelfDiscussion: React.FC = () => {
         await sendMessage(content);
         return;
       }
-      for (let i = 0; i < idsToForward.length; i++) {
-        await sendMessage(i === 0 ? content : '', idsToForward[i]);
+      try {
+        for (let i = 0; i < idsToForward.length; i++) {
+          await sendMessage(i === 0 ? content : '', idsToForward[i]);
+        }
+      } catch (error) {
+        toast.error(t('failed_to_send'));
+        logger.error('Failed to forward self message:', error);
       }
     },
-    [forwardFromMessageIds, sendMessage, clearForward]
+    [forwardFromMessageIds, sendMessage, clearForward, t]
   );
 
   useEffect(() => {

--- a/src/stores/appStore.tsx
+++ b/src/stores/appStore.tsx
@@ -42,9 +42,9 @@ interface AppStoreState {
   // Pending shared content from other apps
   pendingSharedContent: string | null;
   setPendingSharedContent: (content: string | null) => void;
-  // Pending forward message id (used during discussion selection)
-  pendingForwardMessageId: number | null;
-  setPendingForwardMessageId: (messageId: number | null) => void;
+  // Pending forward message ids (used during discussion selection; order = send order)
+  pendingForwardMessageIds: number[];
+  setPendingForwardMessageIds: (messageIds: number[]) => void;
   // MNS support enabled/disabled
   mnsEnabled: boolean;
   setMnsEnabled: (enabled: boolean) => void;
@@ -112,10 +112,10 @@ const useAppStoreBase = create<AppStoreState>()(
       setPendingSharedContent: (content: string | null) => {
         set({ pendingSharedContent: content });
       },
-      // Pending forward message id
-      pendingForwardMessageId: null,
-      setPendingForwardMessageId: (messageId: number | null) => {
-        set({ pendingForwardMessageId: messageId });
+      // Pending forward message ids
+      pendingForwardMessageIds: [],
+      setPendingForwardMessageIds: (messageIds: number[]) => {
+        set({ pendingForwardMessageIds: messageIds });
       },
       // MNS support (disabled by default)
       mnsEnabled: false,

--- a/src/stores/messageStore.tsx
+++ b/src/stores/messageStore.tsx
@@ -6,6 +6,7 @@ import {
   MessageStatus,
   MessageType,
   decodeUserId,
+  SELF_CONTACT_ID,
 } from '@massalabs/gossip-sdk';
 import { createSelectors } from './utils/createSelectors';
 import { useAccountStore } from './accountStore';
@@ -44,8 +45,8 @@ const createStoreId = (): string => {
 
 /**
  * Resolve the optional replyTo / forwardOf fields for a new outgoing message.
- * A forward to the same contact collapses into a reply (quoting that contact's
- * own message). A forward to a different contact stays a forward.
+ * Explicit forwards always produce forwardOf (including same-conversation
+ * forwards). Replies are only created via replyToId.
  */
 async function resolveReplyAndForward(
   contactUserId: string,
@@ -67,13 +68,19 @@ async function resolveReplyAndForward(
   }
 
   if (forwardFromMessageId) {
-    const orig = await getSdk().messages.get(forwardFromMessageId);
+    let orig = await getSdk().messages.get(forwardFromMessageId);
+    // Notes store ciphertext in the shared messages table; decrypt via selfMessages.
+    if (orig?.contactUserId === SELF_CONTACT_ID) {
+      orig = (await getSdk().selfMessages.get(forwardFromMessageId)) ?? orig;
+    }
+
     if (!orig) {
       logger.warn('Forward target not found, sending as regular message');
+    } else if (orig.contactUserId === SELF_CONTACT_ID) {
+      // Notes → conversation: no protocol messageId / bech32 contact id.
+      forwardOf = { originalContent: orig.content };
     } else if (!orig.messageId) {
       throw new Error('Cannot forward a message that has no messageId');
-    } else if (orig.contactUserId === contactUserId) {
-      replyTo = { originalMsgId: orig.messageId };
     } else {
       forwardOf = {
         originalContent: orig.content,

--- a/src/stores/messageStore.tsx
+++ b/src/stores/messageStore.tsx
@@ -68,17 +68,30 @@ async function resolveReplyAndForward(
   }
 
   if (forwardFromMessageId) {
-    let orig = await getSdk().messages.get(forwardFromMessageId);
-    // Notes store ciphertext in the shared messages table; decrypt via selfMessages.
-    if (orig?.contactUserId === SELF_CONTACT_ID) {
-      orig = (await getSdk().selfMessages.get(forwardFromMessageId)) ?? orig;
-    }
+    // Notes are owned by SelfMessageService (encrypted forwardOf). Probe that
+    // path first so ciphertext never hits MessageService's plaintext JSON parser.
+    const orig =
+      (await getSdk().selfMessages.get(forwardFromMessageId)) ??
+      (await getSdk().messages.get(forwardFromMessageId));
 
     if (!orig) {
       logger.warn('Forward target not found, sending as regular message');
     } else if (orig.contactUserId === SELF_CONTACT_ID) {
-      // Notes → conversation: no protocol messageId / bech32 contact id.
-      forwardOf = { originalContent: orig.content };
+      // Notes have no peer contactUserId; cite the owner's public user id so
+      // MESSAGE_TYPE_FORWARD still carries a valid 32-byte citedContactId.
+      // Conv→Notes may leave content empty and store the body in forwardOf.
+      const { userProfile } = useAccountStore.getState();
+      if (!userProfile?.userId) {
+        throw new Error('Cannot forward Notes without an owner user id');
+      }
+      const nestedOriginal = orig.forwardOf?.originalContent;
+      forwardOf = {
+        originalContent:
+          typeof nestedOriginal === 'string' && nestedOriginal.length > 0
+            ? nestedOriginal
+            : orig.content,
+        originalContactId: decodeUserId(userProfile.userId),
+      };
     } else if (!orig.messageId) {
       throw new Error('Cannot forward a message that has no messageId');
     } else {
@@ -161,6 +174,8 @@ const useMessageStoreBase = create<MessageStoreState>((set, get) => ({
         const msgMap = new Map<string, StoreMessage[]>();
         const rxnMap = new Map<string, StoreMessage[]>();
         for (const d of discussions) {
+          // Notes are owned by SelfMessageService / selfMessageStore.
+          if (d.contactUserId === SELF_CONTACT_ID) continue;
           const msgs = await sdk.messages.getVisibleMessages(d.contactUserId);
           const rxns = await sdk.messages.getReactions(d.contactUserId);
           if (msgs.length > 0) {

--- a/src/stores/messageStore.tsx
+++ b/src/stores/messageStore.tsx
@@ -32,6 +32,7 @@ import {
   patchReactionCache,
 } from './messageStore.helpers';
 import { createEventHandlers } from './messageStore.events';
+import { getForwardSourceContent } from '../utils/messages';
 
 const createStoreId = (): string => {
   if (
@@ -49,7 +50,6 @@ const createStoreId = (): string => {
  * forwards). Replies are only created via replyToId.
  */
 async function resolveReplyAndForward(
-  contactUserId: string,
   replyToId: number | undefined,
   forwardFromMessageId: number | undefined
 ): Promise<{
@@ -67,7 +67,7 @@ async function resolveReplyAndForward(
     replyTo = { originalMsgId: orig.messageId };
   }
 
-  if (forwardFromMessageId) {
+  if (forwardFromMessageId != null) {
     // Notes are owned by SelfMessageService (encrypted forwardOf). Probe that
     // path first so ciphertext never hits MessageService's plaintext JSON parser.
     const orig =
@@ -75,8 +75,15 @@ async function resolveReplyAndForward(
       (await getSdk().messages.get(forwardFromMessageId));
 
     if (!orig) {
-      logger.warn('Forward target not found, sending as regular message');
-    } else if (orig.contactUserId === SELF_CONTACT_ID) {
+      throw new Error('Forward target not found');
+    }
+
+    const originalContent = getForwardSourceContent(orig);
+    if (!originalContent) {
+      throw new Error('Cannot forward a message with no visible content');
+    }
+
+    if (orig.contactUserId === SELF_CONTACT_ID) {
       // Notes have no peer contactUserId; cite the owner's public user id so
       // MESSAGE_TYPE_FORWARD still carries a valid 32-byte citedContactId.
       // Conv→Notes may leave content empty and store the body in forwardOf.
@@ -84,19 +91,15 @@ async function resolveReplyAndForward(
       if (!userProfile?.userId) {
         throw new Error('Cannot forward Notes without an owner user id');
       }
-      const nestedOriginal = orig.forwardOf?.originalContent;
       forwardOf = {
-        originalContent:
-          typeof nestedOriginal === 'string' && nestedOriginal.length > 0
-            ? nestedOriginal
-            : orig.content,
+        originalContent,
         originalContactId: decodeUserId(userProfile.userId),
       };
     } else if (!orig.messageId) {
       throw new Error('Cannot forward a message that has no messageId');
     } else {
       forwardOf = {
-        originalContent: orig.content,
+        originalContent,
         originalContactId: decodeUserId(orig.contactUserId),
       };
     }
@@ -216,7 +219,7 @@ const useMessageStoreBase = create<MessageStoreState>((set, get) => ({
     forwardFromMessageId?
   ) => {
     const { userProfile } = useAccountStore.getState();
-    const isForward = !!forwardFromMessageId;
+    const isForward = forwardFromMessageId != null;
     if (
       !userProfile?.userId ||
       (!content.trim() && !isForward) ||
@@ -225,7 +228,6 @@ const useMessageStoreBase = create<MessageStoreState>((set, get) => ({
       return;
 
     const { replyTo, forwardOf } = await resolveReplyAndForward(
-      contactUserId,
       replyToId,
       forwardFromMessageId
     );

--- a/src/stores/selfMessageStore.tsx
+++ b/src/stores/selfMessageStore.tsx
@@ -5,6 +5,7 @@ import {
   MessageDirection,
   MessageStatus,
   MessageType,
+  decodeUserId,
 } from '@massalabs/gossip-sdk';
 import { createSelectors } from './utils/createSelectors';
 import { getSdk } from './sdkStore';
@@ -27,7 +28,10 @@ interface SelfMessageStore {
   isSending: boolean;
   loadMessages: () => Promise<void>;
   loadReactions: () => Promise<void>;
-  sendMessage: (content: string) => Promise<void>;
+  sendMessage: (
+    content: string,
+    forwardFromMessageId?: number
+  ) => Promise<void>;
   editMessage: (id: number, newContent: string) => Promise<void>;
   deleteMessage: (id: number) => Promise<void>;
   sendReaction: (emoji: string, messageDbId: number) => Promise<void>;
@@ -74,14 +78,32 @@ const useSelfMessageStoreBase = create<SelfMessageStore>((set, get) => ({
     }
   },
 
-  sendMessage: async (content: string) => {
+  sendMessage: async (content: string, forwardFromMessageId?: number) => {
     const trimmed = content.trim();
-    if (!trimmed) return;
+    const isForward = forwardFromMessageId != null;
+    if (!trimmed && !isForward) return;
 
     const sdk = getSdk();
     if (!sdk.isSessionOpen) return;
     const userProfile = useAccountStore.getState().userProfile;
     if (!userProfile?.userId) return;
+
+    let forwardOf: Message['forwardOf'];
+    if (forwardFromMessageId != null) {
+      const orig = await sdk.messages.get(forwardFromMessageId);
+      if (!orig) {
+        logger.warn('Forward target not found, sending as regular message');
+      } else {
+        try {
+          forwardOf = {
+            originalContent: orig.content,
+            originalContactId: decodeUserId(orig.contactUserId),
+          };
+        } catch {
+          forwardOf = { originalContent: orig.content };
+        }
+      }
+    }
 
     set({ isSending: true });
 
@@ -98,12 +120,13 @@ const useSelfMessageStoreBase = create<SelfMessageStore>((set, get) => ({
       status: MessageStatus.SENT,
       timestamp: new Date(),
       messageId: localMessageId,
+      forwardOf,
     };
     set(state => ({ messages: [...state.messages, optimistic] }));
     set({ isSending: false });
 
     try {
-      const message = await sdk.selfMessages.send(trimmed);
+      const message = await sdk.selfMessages.send(trimmed, { forwardOf });
       set(state => ({
         messages: state.messages.map(m =>
           m === optimistic ? { ...message, messageId: localMessageId } : m

--- a/src/stores/selfMessageStore.tsx
+++ b/src/stores/selfMessageStore.tsx
@@ -6,6 +6,7 @@ import {
   MessageStatus,
   MessageType,
   decodeUserId,
+  SELF_CONTACT_ID,
 } from '@massalabs/gossip-sdk';
 import { createSelectors } from './utils/createSelectors';
 import { getSdk } from './sdkStore';
@@ -20,6 +21,7 @@ import {
   restoreReactionGroup,
   type ReactionsMap,
 } from './selfMessageStore.helpers';
+import { getForwardSourceContent } from '../utils/messages';
 
 interface SelfMessageStore {
   messages: Message[];
@@ -90,18 +92,29 @@ const useSelfMessageStoreBase = create<SelfMessageStore>((set, get) => ({
 
     let forwardOf: Message['forwardOf'];
     if (forwardFromMessageId != null) {
-      const orig = await sdk.messages.get(forwardFromMessageId);
+      const orig =
+        (await sdk.selfMessages.get(forwardFromMessageId)) ??
+        (await sdk.messages.get(forwardFromMessageId));
       if (!orig) {
-        logger.warn('Forward target not found, sending as regular message');
-      } else {
-        try {
-          forwardOf = {
-            originalContent: orig.content,
-            originalContactId: decodeUserId(orig.contactUserId),
-          };
-        } catch {
-          forwardOf = { originalContent: orig.content };
-        }
+        throw new Error('Forward target not found');
+      }
+
+      const originalContent = getForwardSourceContent(orig);
+      if (!originalContent) {
+        throw new Error('Cannot forward a message with no visible content');
+      }
+
+      const originalContactUserId =
+        orig.contactUserId === SELF_CONTACT_ID
+          ? userProfile.userId
+          : orig.contactUserId;
+      try {
+        forwardOf = {
+          originalContent,
+          originalContactId: decodeUserId(originalContactUserId),
+        };
+      } catch {
+        forwardOf = { originalContent };
       }
     }
 

--- a/src/utils/discussionSelectDestination.ts
+++ b/src/utils/discussionSelectDestination.ts
@@ -1,0 +1,66 @@
+import { SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
+import { ROUTES } from '../constants/routes';
+
+export type DiscussionSelectNavState =
+  | { forwardFromMessageIds: number[] }
+  | { prefilledMessage: string };
+
+export interface DiscussionSelectDestination {
+  path: string;
+  state?: DiscussionSelectNavState;
+  clearPendingForwardIds: boolean;
+  clearPendingSharedContent: boolean;
+}
+
+/**
+ * Pure destination-routing decision for selecting a discussion from the list.
+ * Pending forward IDs always take priority over pending shared content
+ * (including empty-string shared content from Notes with empty `content`).
+ */
+export function resolveDiscussionSelectDestination(
+  contactUserId: string,
+  pendingForwardMessageIds: number[],
+  pendingSharedContent: string | null
+): DiscussionSelectDestination {
+  const hasForward = pendingForwardMessageIds.length > 0;
+
+  if (contactUserId === SELF_CONTACT_ID) {
+    if (hasForward) {
+      return {
+        path: ROUTES.selfDiscussion(),
+        state: { forwardFromMessageIds: pendingForwardMessageIds },
+        clearPendingForwardIds: true,
+        clearPendingSharedContent: true,
+      };
+    }
+    return {
+      path: ROUTES.selfDiscussion(),
+      clearPendingForwardIds: false,
+      clearPendingSharedContent: false,
+    };
+  }
+
+  if (hasForward) {
+    return {
+      path: ROUTES.discussion({ userId: contactUserId }),
+      state: { forwardFromMessageIds: pendingForwardMessageIds },
+      clearPendingForwardIds: true,
+      clearPendingSharedContent: true,
+    };
+  }
+
+  if (pendingSharedContent) {
+    return {
+      path: ROUTES.discussion({ userId: contactUserId }),
+      state: { prefilledMessage: pendingSharedContent },
+      clearPendingForwardIds: false,
+      clearPendingSharedContent: true,
+    };
+  }
+
+  return {
+    path: ROUTES.discussion({ userId: contactUserId }),
+    clearPendingForwardIds: false,
+    clearPendingSharedContent: false,
+  };
+}

--- a/src/utils/discussionSelectDestination.ts
+++ b/src/utils/discussionSelectDestination.ts
@@ -12,6 +12,13 @@ export interface DiscussionSelectDestination {
   clearPendingSharedContent: boolean;
 }
 
+export function hasPendingDiscussionSelection(
+  pendingForwardMessageIds: number[],
+  pendingSharedContent: string | null
+): boolean {
+  return pendingForwardMessageIds.length > 0 || !!pendingSharedContent;
+}
+
 /**
  * Pure destination-routing decision for selecting a discussion from the list.
  * Pending forward IDs always take priority over pending shared content

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -35,3 +35,17 @@ export function hasUnreadMessages(messages: Message[]): boolean {
       message.status === MessageStatus.DELIVERED
   );
 }
+
+/**
+ * Flatten the text a user can see in a message bubble for forwarding.
+ * Forwarded messages render their cited body before the optional comment, so
+ * re-forwarding must preserve both rather than forwarding only `content`.
+ */
+export function getForwardSourceContent(
+  message: Pick<Message, 'content' | 'forwardOf'>
+): string {
+  const parts = [message.forwardOf?.originalContent, message.content].filter(
+    (part): part is string => typeof part === 'string' && part.length > 0
+  );
+  return parts.join('\n\n');
+}

--- a/test/hooks/useDiscussionActions.spec.ts
+++ b/test/hooks/useDiscussionActions.spec.ts
@@ -60,7 +60,7 @@ vi.mock('../../src/stores/appStore', () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       setPendingSharedContent: vi.fn(),
-      setPendingForwardMessageId: vi.fn(),
+      setPendingForwardMessageIds: vi.fn(),
     }),
 }));
 
@@ -94,7 +94,7 @@ interface HarnessProps {
   setEditingMessage: (msg: Message | null) => void;
   setInputPrefill: (text: string | undefined) => void;
   clearForward: () => void;
-  forwardFromMessageId?: number;
+  forwardFromMessageIds?: number[];
 }
 
 function renderHook(container: HTMLDivElement, props: HarnessProps): HookRef {
@@ -108,7 +108,7 @@ function renderHook(container: HTMLDivElement, props: HarnessProps): HookRef {
       contact: { userId: 'contact-1' },
       isSelecting: false,
       t: translate,
-      forwardFromMessageId: props.forwardFromMessageId,
+      forwardFromMessageIds: props.forwardFromMessageIds ?? [],
       setReplyingTo: props.setReplyingTo,
       setEditingMessage: props.setEditingMessage,
       setInputPrefill: props.setInputPrefill,
@@ -165,7 +165,7 @@ describe('useDiscussionActions.handleSendMessage', () => {
       setEditingMessage,
       setInputPrefill,
       clearForward,
-      forwardFromMessageId: 42,
+      forwardFromMessageIds: [42],
     });
 
     let sendPromise!: Promise<void>;
@@ -186,6 +186,38 @@ describe('useDiscussionActions.handleSendMessage', () => {
       resolveSend();
       await sendPromise;
     });
+  });
+
+  it('sends each pending forward id as a separate message on Send', async () => {
+    sendMessageMock.mockResolvedValue(undefined);
+
+    const ref = renderHook(container, {
+      setReplyingTo: vi.fn(),
+      setEditingMessage: vi.fn(),
+      setInputPrefill: vi.fn(),
+      clearForward: vi.fn(),
+      forwardFromMessageIds: [10, 20],
+    });
+
+    await act(async () => {
+      await ref.current!.handleSendMessage('caption');
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageMock).toHaveBeenNthCalledWith(
+      1,
+      'contact-1',
+      'caption',
+      undefined,
+      10
+    );
+    expect(sendMessageMock).toHaveBeenNthCalledWith(
+      2,
+      'contact-1',
+      '',
+      undefined,
+      20
+    );
   });
 
   it('clears editing/prefill synchronously in handleConfirmEdit, before editMessage resolves', async () => {

--- a/test/pages/Discussion.browser.spec.tsx
+++ b/test/pages/Discussion.browser.spec.tsx
@@ -49,6 +49,9 @@ vi.mock('../../src/hooks/useGossipSdk', () => ({
       get: vi.fn().mockResolvedValue(null),
       deleteMessage: mockDeleteMessage,
     },
+    selfMessages: {
+      get: vi.fn().mockResolvedValue(null),
+    },
   }),
 }));
 
@@ -77,7 +80,7 @@ vi.mock('../../src/stores/appStore', () => ({
       showDebugOption: false,
       pendingSharedContent: null,
       setPendingSharedContent: vi.fn(),
-      setPendingForwardMessageId: vi.fn(),
+      setPendingForwardMessageIds: vi.fn(),
     }),
 }));
 
@@ -105,14 +108,19 @@ vi.mock('../../src/components/discussions/SelectionHeader', () => ({
   default: ({
     count,
     onDelete,
+    onForward,
     canDelete,
   }: {
     count: number;
     onDelete?: () => void;
+    onForward?: () => void;
     canDelete?: boolean;
   }) => (
     <div data-testid="selection-header">
       Selecting {count}
+      <button type="button" aria-label="mock multi forward" onClick={onForward}>
+        Forward selected
+      </button>
       {canDelete ? (
         <button type="button" aria-label="mock multi delete" onClick={onDelete}>
           Delete selected

--- a/test/pages/SelfDiscussion.browser.spec.tsx
+++ b/test/pages/SelfDiscussion.browser.spec.tsx
@@ -116,6 +116,7 @@ describe('SelfDiscussion forward to self notes', () => {
     latestForwardPreview = undefined;
     latestForwardCount = undefined;
     mockLocationState = { forwardFromMessageIds: [42] };
+    mockGetSelfMessage.mockResolvedValue(undefined);
     mockGetMessage.mockResolvedValue({
       id: 42,
       content: 'Forwarded note content',
@@ -127,14 +128,52 @@ describe('SelfDiscussion forward to self notes', () => {
     mockSetSelfRetentionPolicy.mockResolvedValue(undefined);
   });
 
-  it('shows forward preview banner without auto-sending', async () => {
+  it('shows conversation forward preview from messages.get content', async () => {
     render(<SelfDiscussion />);
     await act(async () => {});
     await act(async () => {});
 
+    expect(mockGetSelfMessage).toHaveBeenCalledWith(42);
     expect(mockGetMessage).toHaveBeenCalledWith(42);
     expect(mockSendSelfMessage).not.toHaveBeenCalled();
     expect(latestForwardPreview).toBe('Forwarded note content');
+    expect(latestForwardCount).toBe(1);
+  });
+
+  it('previews Conv→Notes empty-content notes via nested forwardOf.originalContent', async () => {
+    mockGetSelfMessage.mockResolvedValue({
+      id: 42,
+      content: '',
+      contactUserId: '__self__',
+      forwardOf: {
+        originalContent: 'original conversation message',
+      },
+    });
+
+    render(<SelfDiscussion />);
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(mockGetSelfMessage).toHaveBeenCalledWith(42);
+    expect(mockGetMessage).not.toHaveBeenCalled();
+    expect(latestForwardPreview).toBe('original conversation message');
+    expect(latestForwardCount).toBe(1);
+  });
+
+  it('previews user-authored Notes via content', async () => {
+    mockGetSelfMessage.mockResolvedValue({
+      id: 42,
+      content: 'my personal note',
+      contactUserId: '__self__',
+    });
+
+    render(<SelfDiscussion />);
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(mockGetSelfMessage).toHaveBeenCalledWith(42);
+    expect(mockGetMessage).not.toHaveBeenCalled();
+    expect(latestForwardPreview).toBe('my personal note');
     expect(latestForwardCount).toBe(1);
   });
 

--- a/test/pages/SelfDiscussion.browser.spec.tsx
+++ b/test/pages/SelfDiscussion.browser.spec.tsx
@@ -5,12 +5,15 @@ import React from 'react';
 import { render } from 'vitest-browser-react';
 import { act } from 'react';
 
-let mockLocationState: { forwardFromMessageId?: number } = {
-  forwardFromMessageId: 42,
+let mockLocationState: {
+  forwardFromMessageIds?: number[];
+} = {
+  forwardFromMessageIds: [42],
 };
 
 const mockNavigate = vi.fn();
 const mockGetMessage = vi.fn();
+const mockGetSelfMessage = vi.fn();
 const mockSendSelfMessage = vi.fn().mockResolvedValue(undefined);
 const mockGetSelfRetentionInfo = vi
   .fn()
@@ -22,10 +25,14 @@ const mockSdk = {
     get: mockGetMessage,
   },
   selfMessages: {
+    get: mockGetSelfMessage,
     getRetentionInfo: mockGetSelfRetentionInfo,
     setRetentionPolicy: mockSetSelfRetentionPolicy,
   },
 };
+
+let latestForwardPreview: string | null | undefined;
+let latestForwardCount: number | undefined;
 
 vi.mock('react-router-dom', () => ({
   useLocation: () => ({ state: mockLocationState }),
@@ -39,6 +46,14 @@ vi.mock('../../src/stores/sdkStore', () => ({
       sdk: () => mockSdk,
     },
   },
+}));
+
+vi.mock('../../src/stores/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      setPendingSharedContent: vi.fn(),
+      setPendingForwardMessageIds: vi.fn(),
+    }),
 }));
 
 vi.mock('../../src/stores/selfMessageStore', () => ({
@@ -68,15 +83,27 @@ vi.mock('../../src/components/ui/BackButton', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, options?: { duration?: string }) =>
-      options?.duration ? `${key}:${options.duration}` : key,
+    t: (key: string, options?: { duration?: string; count?: number }) =>
+      options?.duration
+        ? `${key}:${options.duration}`
+        : options?.count != null
+          ? `${key}:${options.count}`
+          : key,
     i18n: { language: 'en' },
   }),
   initReactI18next: { type: '3rdParty', init: () => {} },
 }));
 
 vi.mock('../../src/components/discussions/MessageInput', () => ({
-  default: () => {
+  default: ({
+    forwardPreview,
+    forwardCount,
+  }: {
+    forwardPreview?: string | null;
+    forwardCount?: number;
+  }) => {
+    latestForwardPreview = forwardPreview;
+    latestForwardCount = forwardCount;
     return <div data-testid="mock-message-input" />;
   },
 }));
@@ -86,24 +113,29 @@ import SelfDiscussion from '../../src/pages/SelfDiscussion';
 describe('SelfDiscussion forward to self notes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLocationState = { forwardFromMessageId: 42 };
+    latestForwardPreview = undefined;
+    latestForwardCount = undefined;
+    mockLocationState = { forwardFromMessageIds: [42] };
     mockGetMessage.mockResolvedValue({
       id: 42,
       content: 'Forwarded note content',
+      contactUserId:
+        'gossip1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
     });
     mockSendSelfMessage.mockResolvedValue(undefined);
     mockGetSelfRetentionInfo.mockResolvedValue({ duration: null, setAt: null });
     mockSetSelfRetentionPolicy.mockResolvedValue(undefined);
   });
 
-  it('prefills the input with the forwarded content (no auto-send)', async () => {
+  it('shows forward preview banner without auto-sending', async () => {
     render(<SelfDiscussion />);
     await act(async () => {});
+    await act(async () => {});
 
-    // The message is fetched from the SDK but NOT auto-sent; the user reviews
-    // and hits send explicitly.
     expect(mockGetMessage).toHaveBeenCalledWith(42);
     expect(mockSendSelfMessage).not.toHaveBeenCalled();
+    expect(latestForwardPreview).toBe('Forwarded note content');
+    expect(latestForwardCount).toBe(1);
   });
 
   it('loads and updates self retention duration from settings', async () => {

--- a/test/pages/SelfDiscussionSelection.browser.spec.tsx
+++ b/test/pages/SelfDiscussionSelection.browser.spec.tsx
@@ -50,7 +50,18 @@ vi.mock('../../src/hooks/useGossipSdk', () => ({
       get: vi.fn().mockResolvedValue(null),
       deleteMessage: vi.fn().mockResolvedValue(true),
     },
+    selfMessages: {
+      get: vi.fn().mockResolvedValue(null),
+    },
   }),
+}));
+
+vi.mock('../../src/stores/appStore', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      setPendingSharedContent: vi.fn(),
+      setPendingForwardMessageIds: vi.fn(),
+    }),
 }));
 
 vi.mock('../../src/stores/selfMessageStore', () => ({
@@ -79,12 +90,14 @@ vi.mock('../../src/components/discussions/SelectionHeader', () => ({
     count,
     onClear,
     onCopy,
+    onForward,
     onDelete,
     canDelete,
   }: {
     count: number;
     onClear: () => void;
     onCopy: () => void;
+    onForward: () => void;
     onDelete: () => void;
     canDelete?: boolean;
   }) => (
@@ -92,6 +105,9 @@ vi.mock('../../src/components/discussions/SelectionHeader', () => ({
       <span data-testid="selection-count">{count}</span>
       <button type="button" aria-label="clear selection" onClick={onClear}>
         Clear
+      </button>
+      <button type="button" aria-label="forward selected" onClick={onForward}>
+        Forward
       </button>
       <button type="button" aria-label="copy selected" onClick={onCopy}>
         Copy
@@ -158,7 +174,7 @@ describe('SelfDiscussion message selection', () => {
     ];
   });
 
-  it('shows SelectionHeader with copy and delete buttons when a message is selected', async () => {
+  it('shows SelectionHeader with forward, copy and delete buttons when a message is selected', async () => {
     await render(<SelfDiscussion />);
 
     // Initially no selection header
@@ -179,7 +195,10 @@ describe('SelfDiscussion message selection', () => {
       .element(page.getByTestId('selection-count'))
       .toHaveTextContent('1');
 
-    // Copy and delete buttons should be present
+    // Forward, copy and delete buttons should be present
+    await expect
+      .element(page.getByRole('button', { name: 'forward selected' }))
+      .toBeInTheDocument();
     await expect
       .element(page.getByRole('button', { name: 'copy selected' }))
       .toBeInTheDocument();

--- a/test/stores/messageStore.spec.ts
+++ b/test/stores/messageStore.spec.ts
@@ -606,4 +606,74 @@ describe('MessageStore forward resolution', () => {
       SELF_CONTACT_ID
     );
   });
+
+  it('re-forwards a forward-only DM with a non-empty wire payload', async () => {
+    const originalMsgId = new Uint8Array(12).fill(4);
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
+    mockSdk.messages.get.mockResolvedValue({
+      id: 90,
+      content: '',
+      contactUserId,
+      messageId: originalMsgId,
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.INCOMING,
+      status: MessageStatus.DELIVERED,
+      timestamp: new Date(),
+      forwardOf: { originalContent: 'cited body' },
+    } satisfies Message);
+
+    await useMessageStore
+      .getState()
+      .sendMessage(contactUserId, '', undefined, 90);
+
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.forwardOf?.originalContent).toBe('cited body');
+    const wire = serializeForwardMessage(
+      sent.forwardOf!.originalContent!,
+      sent.content,
+      new Uint8Array(12).fill(6),
+      sent.forwardOf!.originalContactId
+    );
+    expect(deserializeMessage(wire).forwardOf?.originalContent).toBe(
+      'cited body'
+    );
+  });
+
+  it('preserves a forwarded DM cited body and comment', async () => {
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
+    mockSdk.messages.get.mockResolvedValue({
+      id: 91,
+      content: 'comment',
+      contactUserId,
+      messageId: new Uint8Array(12).fill(5),
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.INCOMING,
+      status: MessageStatus.DELIVERED,
+      timestamp: new Date(),
+      forwardOf: { originalContent: 'cited body' },
+    } satisfies Message);
+
+    await useMessageStore
+      .getState()
+      .sendMessage(contactUserId, '', undefined, 91);
+
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.forwardOf?.originalContent).toBe('cited body\n\ncomment');
+  });
+
+  it('fails closed when a forward source no longer exists', async () => {
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
+    mockSdk.messages.get.mockResolvedValue(undefined);
+
+    await expect(
+      useMessageStore.getState().sendMessage(contactUserId, '', undefined, 999)
+    ).rejects.toThrow('Forward target not found');
+
+    expect(mockSdk.messages.send).not.toHaveBeenCalled();
+    expect(
+      useMessageStore.getState().getMessagesForContact(contactUserId)
+    ).toHaveLength(0);
+  });
 });

--- a/test/stores/messageStore.spec.ts
+++ b/test/stores/messageStore.spec.ts
@@ -8,6 +8,8 @@ import {
   MessageDirection,
   MessageStatus,
   MessageType,
+  encodeUserId,
+  SELF_CONTACT_ID,
 } from '@massalabs/gossip-sdk';
 import { recomputeFullCache } from '../../src/stores/messageStore.helpers';
 
@@ -37,6 +39,9 @@ const mockSdk = {
     findMessageByMsgId: vi.fn(async () => undefined as Message | undefined),
     deleteMessage: vi.fn(async () => true),
     editMessage: vi.fn(async () => true),
+  },
+  selfMessages: {
+    get: vi.fn(async () => undefined as unknown as Message | undefined),
   },
   discussions: {
     list: vi.fn(async () => []),
@@ -344,5 +349,95 @@ describe('MessageStore reactions', () => {
       useMessageStore.getState().reactionsByContact.get(contactUserId) ?? [];
     expect(remainingReactions).toHaveLength(1);
     expect(remainingReactions[0].id).toBe(incomingReaction.id);
+  });
+});
+
+describe('MessageStore forward resolution', () => {
+  const contactUserId = encodeUserId(new Uint8Array(32).fill(7));
+
+  beforeEach(() => {
+    listeners.clear();
+    useMessageStore.setState({
+      messagesByContact: new Map(),
+      reactionsByContact: new Map(),
+      reactionGroupsCache: new Map(),
+      currentContactUserId: null,
+      cleanupFn: null,
+      isInitializing: false,
+    } as unknown as ReturnType<(typeof useMessageStore)['getState']>);
+    mockSdk.isSessionOpen = true;
+    mockSdk.messages.send.mockClear();
+    mockSdk.messages.get.mockReset();
+    mockSdk.selfMessages.get.mockReset();
+    useMessageStore.getState().init();
+  });
+
+  afterEach(() => {
+    useMessageStore.getState().cleanup();
+  });
+
+  it('keeps same-conversation explicit Forward as forwardOf (not replyTo)', async () => {
+    const originalMsgId = new Uint8Array(12).fill(9);
+    mockSdk.messages.get.mockResolvedValue({
+      id: 42,
+      content: 'original text',
+      contactUserId,
+      messageId: originalMsgId,
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.INCOMING,
+      status: MessageStatus.DELIVERED,
+      timestamp: new Date(),
+    } satisfies Message);
+
+    await useMessageStore
+      .getState()
+      .sendMessage(contactUserId, '', undefined, 42);
+
+    expect(mockSdk.messages.send).toHaveBeenCalledTimes(1);
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.replyTo).toBeUndefined();
+    expect(sent.forwardOf).toEqual({
+      originalContent: 'original text',
+      originalContactId: expect.any(Uint8Array),
+    });
+    expect(sent.forwardOf!.originalContactId).toEqual(
+      new Uint8Array(32).fill(7)
+    );
+  });
+
+  it('forwards Notes → conversation without throwing on SELF_CONTACT_ID', async () => {
+    mockSdk.messages.get.mockResolvedValue({
+      id: 77,
+      content: 'ciphertext-or-placeholder',
+      contactUserId: SELF_CONTACT_ID,
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.OUTGOING,
+      status: MessageStatus.SENT,
+      timestamp: new Date(),
+    } satisfies Message);
+    mockSdk.selfMessages.get.mockResolvedValue({
+      id: 77,
+      content: 'decrypted notes text',
+      contactUserId: SELF_CONTACT_ID,
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.OUTGOING,
+      status: MessageStatus.SENT,
+      timestamp: new Date(),
+    } satisfies Message);
+
+    await expect(
+      useMessageStore.getState().sendMessage(contactUserId, '', undefined, 77)
+    ).resolves.toBeUndefined();
+
+    expect(mockSdk.selfMessages.get).toHaveBeenCalledWith(77);
+    expect(mockSdk.messages.send).toHaveBeenCalledTimes(1);
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.replyTo).toBeUndefined();
+    expect(sent.forwardOf).toEqual({
+      originalContent: 'decrypted notes text',
+    });
   });
 });

--- a/test/stores/messageStore.spec.ts
+++ b/test/stores/messageStore.spec.ts
@@ -12,6 +12,10 @@ import {
   SELF_CONTACT_ID,
 } from '@massalabs/gossip-sdk';
 import { recomputeFullCache } from '../../src/stores/messageStore.helpers';
+import {
+  serializeForwardMessage,
+  deserializeMessage,
+} from '../../gossip-sdk/src/utils/messageSerialization';
 
 // ---------------------------------------------------------------------------
 // Mock SDK with event emitter so optimistic sends flow through the store
@@ -63,13 +67,17 @@ vi.mock('../../src/stores/sdkStore', () => ({
   getSdk: () => mockSdk,
 }));
 
-vi.mock('../../src/stores/accountStore', () => ({
-  useAccountStore: {
-    getState: vi.fn(() => ({
-      userProfile: { userId: 'test-user-id' },
-    })),
-  },
-}));
+vi.mock('../../src/stores/accountStore', async () => {
+  const { encodeUserId } = await import('@massalabs/gossip-sdk');
+  const ownerUserId = encodeUserId(new Uint8Array(32).fill(1));
+  return {
+    useAccountStore: {
+      getState: vi.fn(() => ({
+        userProfile: { userId: ownerUserId },
+      })),
+    },
+  };
+});
 
 describe('MessageStore reactions', () => {
   const contactUserId = 'contact-1';
@@ -378,6 +386,7 @@ describe('MessageStore forward resolution', () => {
 
   it('keeps same-conversation explicit Forward as forwardOf (not replyTo)', async () => {
     const originalMsgId = new Uint8Array(12).fill(9);
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
     mockSdk.messages.get.mockResolvedValue({
       id: 42,
       content: 'original text',
@@ -394,6 +403,8 @@ describe('MessageStore forward resolution', () => {
       .getState()
       .sendMessage(contactUserId, '', undefined, 42);
 
+    expect(mockSdk.selfMessages.get).toHaveBeenCalledWith(42);
+    expect(mockSdk.messages.get).toHaveBeenCalledWith(42);
     expect(mockSdk.messages.send).toHaveBeenCalledTimes(1);
     const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
     expect(sent.replyTo).toBeUndefined();
@@ -406,22 +417,70 @@ describe('MessageStore forward resolution', () => {
     );
   });
 
-  it('forwards Notes → conversation without throwing on SELF_CONTACT_ID', async () => {
+  it('keeps Conversation → Conversation forward with peer originalContactId', async () => {
+    const peerContactUserId = encodeUserId(new Uint8Array(32).fill(8));
+    const originalMsgId = new Uint8Array(12).fill(4);
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
     mockSdk.messages.get.mockResolvedValue({
-      id: 77,
-      content: 'ciphertext-or-placeholder',
-      contactUserId: SELF_CONTACT_ID,
-      ownerUserId: 'test-user-id',
+      id: 55,
+      content: 'from another chat',
+      contactUserId: peerContactUserId,
+      messageId: originalMsgId,
+      ownerUserId: 'peer-owner',
       type: MessageType.TEXT,
-      direction: MessageDirection.OUTGOING,
-      status: MessageStatus.SENT,
+      direction: MessageDirection.INCOMING,
+      status: MessageStatus.DELIVERED,
       timestamp: new Date(),
     } satisfies Message);
+
+    await useMessageStore
+      .getState()
+      .sendMessage(contactUserId, 'note', undefined, 55);
+
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.replyTo).toBeUndefined();
+    expect(sent.forwardOf?.originalContent).toBe('from another chat');
+    expect(sent.forwardOf?.originalContactId).toEqual(
+      new Uint8Array(32).fill(8)
+    );
+  });
+
+  it('keeps Reply via replyToId unchanged (replyTo, not forwardOf)', async () => {
+    const originalMsgId = new Uint8Array(12).fill(5);
+    mockSdk.messages.get.mockResolvedValue({
+      id: 99,
+      content: 'quoted',
+      contactUserId,
+      messageId: originalMsgId,
+      ownerUserId: 'test-user-id',
+      type: MessageType.TEXT,
+      direction: MessageDirection.INCOMING,
+      status: MessageStatus.DELIVERED,
+      timestamp: new Date(),
+    } satisfies Message);
+
+    await useMessageStore
+      .getState()
+      .sendMessage(contactUserId, 'reply body', 99);
+
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.forwardOf).toBeUndefined();
+    expect(sent.replyTo).toEqual({ originalMsgId });
+    expect(mockSdk.selfMessages.get).not.toHaveBeenCalled();
+  });
+
+  it('forwards user-authored Notes → conversation via selfMessages only (no plaintext JSON parse)', async () => {
+    const ownerUserId = encodeUserId(new Uint8Array(32).fill(1));
+    const ownerContactId = new Uint8Array(32).fill(1);
+    // Simulate MessageService throwing if encrypted Notes forwardOf were parsed.
+    mockSdk.messages.get.mockImplementation(async () => {
+      throw new Error('encrypted Notes forwardOf must not hit MessageService');
+    });
     mockSdk.selfMessages.get.mockResolvedValue({
       id: 77,
       content: 'decrypted notes text',
       contactUserId: SELF_CONTACT_ID,
-      ownerUserId: 'test-user-id',
+      ownerUserId,
       type: MessageType.TEXT,
       direction: MessageDirection.OUTGOING,
       status: MessageStatus.SENT,
@@ -433,11 +492,118 @@ describe('MessageStore forward resolution', () => {
     ).resolves.toBeUndefined();
 
     expect(mockSdk.selfMessages.get).toHaveBeenCalledWith(77);
+    expect(mockSdk.messages.get).not.toHaveBeenCalled();
     expect(mockSdk.messages.send).toHaveBeenCalledTimes(1);
     const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
     expect(sent.replyTo).toBeUndefined();
     expect(sent.forwardOf).toEqual({
       originalContent: 'decrypted notes text',
+      originalContactId: ownerContactId,
     });
+
+    // Existing FORWARD wire format must round-trip for old and new clients.
+    const messageId = new Uint8Array(12).fill(3);
+    const wire = serializeForwardMessage(
+      sent.forwardOf!.originalContent!,
+      sent.content,
+      messageId,
+      sent.forwardOf!.originalContactId
+    );
+    const decoded = deserializeMessage(wire);
+    expect(decoded.forwardOf?.originalContent).toBe('decrypted notes text');
+    expect(decoded.forwardOf?.originalContactId).toEqual(ownerContactId);
+  });
+
+  it('re-forwards Conv→Notes (empty composer) using nested forwardOf.originalContent', async () => {
+    const ownerUserId = encodeUserId(new Uint8Array(32).fill(1));
+    const ownerContactId = new Uint8Array(32).fill(1);
+    const peerContactId = new Uint8Array(32).fill(7);
+    // After reload, selfMessages.get returns decrypted Note: empty content,
+    // body only in forwardOf (as stored by Conv→Notes with no composer text).
+    mockSdk.messages.get.mockImplementation(async () => {
+      throw new Error('encrypted Notes forwardOf must not hit MessageService');
+    });
+    mockSdk.selfMessages.get.mockResolvedValue({
+      id: 88,
+      content: '',
+      contactUserId: SELF_CONTACT_ID,
+      ownerUserId,
+      type: MessageType.TEXT,
+      direction: MessageDirection.OUTGOING,
+      status: MessageStatus.SENT,
+      timestamp: new Date(),
+      forwardOf: {
+        originalContent: 'original conversation message',
+        originalContactId: peerContactId,
+      },
+    } satisfies Message);
+
+    await expect(
+      useMessageStore.getState().sendMessage(contactUserId, '', undefined, 88)
+    ).resolves.toBeUndefined();
+
+    expect(mockSdk.selfMessages.get).toHaveBeenCalledWith(88);
+    expect(mockSdk.messages.get).not.toHaveBeenCalled();
+    const sent = mockSdk.messages.send.mock.calls[0][0] as Message;
+    expect(sent.replyTo).toBeUndefined();
+    expect(sent.forwardOf?.originalContent).toBe(
+      'original conversation message'
+    );
+    expect(sent.forwardOf?.originalContactId).toEqual(ownerContactId);
+
+    const messageId = new Uint8Array(12).fill(6);
+    const wire = serializeForwardMessage(
+      sent.forwardOf!.originalContent!,
+      sent.content,
+      messageId,
+      sent.forwardOf!.originalContactId
+    );
+    const decoded = deserializeMessage(wire);
+    expect(decoded.forwardOf?.originalContent).toBe(
+      'original conversation message'
+    );
+    expect(decoded.forwardOf?.originalContent?.length).toBeGreaterThan(0);
+    expect(decoded.forwardOf?.originalContactId).toEqual(ownerContactId);
+  });
+
+  it('skips SELF_CONTACT_ID on init so encrypted Notes forwardOf never hits MessageService', async () => {
+    useMessageStore.getState().cleanup();
+    listeners.clear();
+    useMessageStore.setState({
+      messagesByContact: new Map(),
+      reactionsByContact: new Map(),
+      reactionGroupsCache: new Map(),
+      currentContactUserId: null,
+      cleanupFn: null,
+      isInitializing: false,
+    } as unknown as ReturnType<(typeof useMessageStore)['getState']>);
+
+    mockSdk.discussions.list.mockResolvedValue([
+      { contactUserId: SELF_CONTACT_ID },
+      { contactUserId },
+    ]);
+    mockSdk.messages.getVisibleMessages.mockImplementation(
+      async (id: string) => {
+        if (id === SELF_CONTACT_ID) {
+          throw new Error(
+            'getVisibleMessages(SELF) must not run after Conv→Notes'
+          );
+        }
+        return [];
+      }
+    );
+    mockSdk.messages.getReactions.mockResolvedValue([]);
+
+    await expect(useMessageStore.getState().init()).resolves.toBeUndefined();
+
+    expect(mockSdk.messages.getVisibleMessages).toHaveBeenCalledWith(
+      contactUserId
+    );
+    expect(mockSdk.messages.getVisibleMessages).not.toHaveBeenCalledWith(
+      SELF_CONTACT_ID
+    );
+    expect(mockSdk.messages.getReactions).not.toHaveBeenCalledWith(
+      SELF_CONTACT_ID
+    );
   });
 });

--- a/test/stores/selfMessageStore.spec.ts
+++ b/test/stores/selfMessageStore.spec.ts
@@ -4,6 +4,7 @@ import {
   MessageDirection,
   MessageStatus,
   MessageType,
+  encodeUserId,
 } from '@massalabs/gossip-sdk';
 
 let resolveGetMessages: ((messages: Message[]) => void) | null = null;
@@ -11,7 +12,11 @@ let resolveSend: ((message: Message) => void) | null = null;
 
 const mockSdk = {
   isSessionOpen: true,
+  messages: {
+    get: vi.fn(async () => undefined as Message | undefined),
+  },
   selfMessages: {
+    get: vi.fn(async () => undefined as Message | undefined),
     getMessages: vi.fn(
       () =>
         new Promise<Message[]>(resolve => {
@@ -75,6 +80,10 @@ beforeEach(() => {
   resolveGetMessages = null;
   resolveSend = null;
   vi.clearAllMocks();
+  mockSdk.messages.get.mockReset();
+  mockSdk.messages.get.mockResolvedValue(undefined);
+  mockSdk.selfMessages.get.mockReset();
+  mockSdk.selfMessages.get.mockResolvedValue(undefined);
 });
 
 describe('selfMessageStore.loadMessages', () => {
@@ -140,5 +149,70 @@ describe('selfMessageStore.sendMessage + concurrent loadMessages', () => {
     const final = useSelfMessageStore.getState().messages;
     expect(final).toHaveLength(1);
     expect(final[0].id).toBe(42);
+  });
+});
+
+describe('selfMessageStore forwarding', () => {
+  it('forwards Note -> Note from decrypted selfMessages content', async () => {
+    mockSdk.selfMessages.get.mockResolvedValue(
+      makeMessage({ id: 77, content: 'decrypted note' })
+    );
+    mockSdk.messages.get.mockRejectedValue(
+      new Error('encrypted Notes must not use messages.get')
+    );
+    mockSdk.selfMessages.send.mockResolvedValueOnce(
+      makeMessage({
+        id: 78,
+        content: '',
+        forwardOf: { originalContent: 'decrypted note' },
+      })
+    );
+
+    await useSelfMessageStore.getState().sendMessage('', 77);
+
+    expect(mockSdk.selfMessages.get).toHaveBeenCalledWith(77);
+    expect(mockSdk.messages.get).not.toHaveBeenCalled();
+    expect(mockSdk.selfMessages.send).toHaveBeenCalledWith('', {
+      forwardOf: { originalContent: 'decrypted note' },
+    });
+  });
+});
+
+describe('selfMessageStore forwarded-message flattening', () => {
+  it('preserves cited content and comment for DM -> Note', async () => {
+    const peerId = encodeUserId(new Uint8Array(32).fill(7));
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
+    mockSdk.messages.get.mockResolvedValue(
+      makeMessage({
+        id: 80,
+        contactUserId: peerId,
+        content: 'comment',
+        forwardOf: { originalContent: 'cited body' },
+      })
+    );
+    mockSdk.selfMessages.send.mockResolvedValueOnce(
+      makeMessage({ id: 81, content: '' })
+    );
+
+    await useSelfMessageStore.getState().sendMessage('', 80);
+
+    expect(mockSdk.selfMessages.send).toHaveBeenCalledWith('', {
+      forwardOf: {
+        originalContent: 'cited body\n\ncomment',
+        originalContactId: new Uint8Array(32).fill(7),
+      },
+    });
+  });
+
+  it('fails closed when the source no longer exists', async () => {
+    mockSdk.selfMessages.get.mockResolvedValue(undefined);
+    mockSdk.messages.get.mockResolvedValue(undefined);
+
+    await expect(
+      useSelfMessageStore.getState().sendMessage('', 999)
+    ).rejects.toThrow('Forward target not found');
+
+    expect(mockSdk.selfMessages.send).not.toHaveBeenCalled();
+    expect(useSelfMessageStore.getState().messages).toHaveLength(0);
   });
 });

--- a/test/utils/discussionSelectDestination.node.spec.ts
+++ b/test/utils/discussionSelectDestination.node.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
+import { ROUTES } from '../../src/constants/routes';
+import { resolveDiscussionSelectDestination } from '../../src/utils/discussionSelectDestination';
+
+describe('resolveDiscussionSelectDestination', () => {
+  const contactUserId = 'contact-user-id';
+
+  it('prioritizes pendingForwardMessageIds over empty pendingSharedContent', () => {
+    const result = resolveDiscussionSelectDestination(contactUserId, [42], '');
+
+    expect(result).toEqual({
+      path: ROUTES.discussion({ userId: contactUserId }),
+      state: { forwardFromMessageIds: [42] },
+      clearPendingForwardIds: true,
+      clearPendingSharedContent: true,
+    });
+  });
+
+  it('uses prefilledMessage when only pendingSharedContent is set', () => {
+    const result = resolveDiscussionSelectDestination(
+      contactUserId,
+      [],
+      'shared text'
+    );
+
+    expect(result).toEqual({
+      path: ROUTES.discussion({ userId: contactUserId }),
+      state: { prefilledMessage: 'shared text' },
+      clearPendingForwardIds: false,
+      clearPendingSharedContent: true,
+    });
+  });
+
+  it('navigates normally when neither pending forward nor shared content is active', () => {
+    const result = resolveDiscussionSelectDestination(contactUserId, [], null);
+
+    expect(result).toEqual({
+      path: ROUTES.discussion({ userId: contactUserId }),
+      clearPendingForwardIds: false,
+      clearPendingSharedContent: false,
+    });
+  });
+
+  it('routes Notes (SELF) with pending forward ids and clears both pending fields', () => {
+    const result = resolveDiscussionSelectDestination(
+      SELF_CONTACT_ID,
+      [42],
+      ''
+    );
+
+    expect(result).toEqual({
+      path: ROUTES.selfDiscussion(),
+      state: { forwardFromMessageIds: [42] },
+      clearPendingForwardIds: true,
+      clearPendingSharedContent: true,
+    });
+  });
+});

--- a/test/utils/discussionSelectDestination.node.spec.ts
+++ b/test/utils/discussionSelectDestination.node.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { SELF_CONTACT_ID } from '@massalabs/gossip-sdk';
 import { ROUTES } from '../../src/constants/routes';
-import { resolveDiscussionSelectDestination } from '../../src/utils/discussionSelectDestination';
+import {
+  hasPendingDiscussionSelection,
+  resolveDiscussionSelectDestination,
+} from '../../src/utils/discussionSelectDestination';
 
 describe('resolveDiscussionSelectDestination', () => {
   const contactUserId = 'contact-user-id';
@@ -55,5 +58,16 @@ describe('resolveDiscussionSelectDestination', () => {
       clearPendingForwardIds: true,
       clearPendingSharedContent: true,
     });
+  });
+});
+
+describe('hasPendingDiscussionSelection', () => {
+  it('stays active for forward-only messages with empty top-level content', () => {
+    expect(hasPendingDiscussionSelection([42], '')).toBe(true);
+  });
+
+  it('is inactive when neither a forward nor shared content is pending', () => {
+    expect(hasPendingDiscussionSelection([], null)).toBe(false);
+    expect(hasPendingDiscussionSelection([], '')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds multi-message forwarding from message selection mode.

Users can select multiple messages and forward them using the existing forwarding flow.

Supported flows:
- Conversation → Conversation
- Conversation → Notes
- Notes → Conversation

Messages are forwarded separately in timestamp order and require explicit confirmation from the destination composer.

Closes #643

## Contributor License Agreement

- [x] I have accepted the Gossip ICLA, or I am a non-human account expressly
      allowed by the maintainers.
- [ ] If an employer owns or controls rights in my Contribution, the employer
      has authorized all required grants, waived or transferred those rights, or
      provided CCLA coverage.
- [ ] Every identifiable human author or co-author of contributed material on
      this pull request has completed the applicable CLA process.

See [CONTRIBUTING.md](../CONTRIBUTING.md) and the
[Contributor Privacy Notice](../CLA/PRIVACY.md) for details.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor, maintenance, or documentation
- [ ] Security-relevant change

## Components

- [x] Web application (`src/`)
- [x] SDK (`gossip-sdk/`)
- [ ] Rust or WASM (`wasm/`)
- [ ] iOS (`ios/`)
- [ ] Android (`android/`)
- [ ] Tooling, CI, or build configuration
- [ ] Documentation or legal files

## Verification

- [ ] `npm run fmt:check`
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build:sdk` when SDK or WASM files changed
- [ ] `cargo fmt --manifest-path wasm/Cargo.toml --all -- --check` when Rust changed
- [ ] `cargo clippy --manifest-path wasm/Cargo.toml --workspace --all-targets` when Rust changed
- [ ] `cargo test --manifest-path wasm/Cargo.toml --workspace --all-targets` when Rust changed
- [x] Manual testing described below

### Manual Test Notes

Tested locally on the PWA.

- Conversation → Conversation
- Conversation → Notes
- Notes → Conversation
- Single-message forwarding
- Multi-message forwarding to the same conversation

All tested flows worked as expected.

## Breaking Changes

None.

## Additional Notes

Notes encryption at rest is preserved.

Explicit forwarding always creates `forwardOf`, including when forwarding to the same conversation. Reply behavior remains unchanged.

`npm run fmt:check` currently reports pre-existing formatting issues across the repository. The files modified by this PR pass the Prettier check.